### PR TITLE
docs: add research README and improve pre-commit documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,6 +233,49 @@ This project uses a variety of tools for different purposes. Adherence to this t
 *   **Design System:** The front-end assets and framework implemented by Claude.
 *   **Formal Proof Setup:** The setup and configuration for Lean 4 must be documented.
 
+## Troubleshooting CI Failures
+
+### Pre-commit Hook Failures
+
+If CI fails due to formatting or type errors, follow these steps:
+
+1. **Run pre-commit locally:**
+   ```bash
+   pre-commit run --all-files
+   ```
+
+2. **Auto-fix formatting issues:**
+   Pre-commit will automatically fix `black` formatting issues. After running, stage the changes:
+   ```bash
+   git add -u
+   git commit -m "style: apply black formatting"
+   ```
+
+3. **Fix mypy type errors:**
+   Type errors require manual fixes. Review the output and update type hints accordingly.
+
+4. **Re-run pre-commit:**
+   Ensure all checks pass before pushing:
+   ```bash
+   pre-commit run --all-files
+   ```
+
+### Common Issues
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `black would reformat` | Code not formatted | Run `black .` or `pre-commit run black --all-files` |
+| `mypy: error` | Type annotation issues | Add/fix type hints per mypy output |
+| `pre-commit not found` | Hooks not installed | Run `pre-commit install` |
+| `ModuleNotFoundError` | Dependencies missing | Run `pip install -r requirements.txt` |
+
+### Keeping Pre-commit Updated
+
+Periodically update pre-commit hooks to their latest versions:
+```bash
+pre-commit autoupdate
+```
+
 ## Directory Structure
 
 This project follows a defined directory structure to keep our work organized.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Follow these instructions to set up a local development environment.
     pre-commit install
     ```
 
+5.  **Run pre-commit on all files (recommended):**
+    Before starting work, run pre-commit on the entire codebase to ensure everything is properly formatted:
+    ```bash
+    pre-commit run --all-files
+    ```
+
 ## Usage
 
 The core work of this project is divided into theoretical development and computational experiments.

--- a/research/README.md
+++ b/research/README.md
@@ -1,0 +1,48 @@
+# Research Directory
+
+This directory contains the **ground truth documentation** for all synthetic experiments in the QBP project. Each file defines the theoretical expectations, experimental parameters, and acceptance criteria that our simulations must satisfy.
+
+## Purpose
+
+As per [Rule 5 in CONTRIBUTING.md](../CONTRIBUTING.md):
+
+> **Link Tests to Reality:** Every automated test must be a "synthetic experiment" that simulates a real, physically verifiable experiment. This connection must be explicitly documented.
+
+These research files serve as the bridge between real physics and our quaternion-based simulations. They define:
+
+- The physical experiment being modeled
+- Expected theoretical predictions (from standard QM or QFT)
+- Acceptance criteria for our implementation
+- References to experimental literature
+
+## File Naming Convention
+
+Files follow the pattern: `{NN}_{experiment_name}_expected_results.md`
+
+- `{NN}`: Two-digit experiment number matching the `/experiments` directory
+- `{experiment_name}`: Snake_case description of the experiment
+- `_expected_results.md`: Standard suffix indicating ground truth documentation
+
+## Experiments
+
+| # | Experiment | Research File | Status |
+|---|------------|---------------|--------|
+| 01 | Stern-Gerlach | [01_stern_gerlach_expected_results.md](01_stern_gerlach_expected_results.md) | Implemented |
+| 02 | Double-Slit | [02_double_slit_expected_results.md](02_double_slit_expected_results.md) | Planned |
+| 03 | Lamb Shift | [03_lamb_shift_expected_results.md](03_lamb_shift_expected_results.md) | Planned |
+| 04 | Anomalous g-2 | [04_g-2_expected_results.md](04_g-2_expected_results.md) | Planned |
+| 05 | Bell's Theorem | [05_bell_theorem_expected_results.md](05_bell_theorem_expected_results.md) | Planned |
+| 06 | Particle Statistics | [06_particle_statistics_derivation.md](06_particle_statistics_derivation.md) | Planned |
+| 07 | Positronium Ground State | [07_positronium_ground_state_expected_results.md](07_positronium_ground_state_expected_results.md) | Planned |
+| 08 | Hydrogen Spectrum | [08_hydrogen_spectrum_expected_results.md](08_hydrogen_spectrum_expected_results.md) | Planned |
+| 09 | Gravity Tests | [09_gravity_tests_expected_results.md](09_gravity_tests_expected_results.md) | Planned |
+
+## Usage
+
+When implementing a new experiment:
+
+1. Read the corresponding research file to understand the physics
+2. Note the expected theoretical values and acceptance criteria
+3. Implement the simulation in `/experiments/{NN}_{name}/`
+4. Create tests in `/tests/physics/` that validate against the research file
+5. Document any deviations or refinements needed


### PR DESCRIPTION
## Summary
- Create `research/README.md` explaining directory purpose, file naming conventions, and linking all 9 experiments with status
- Add explicit "Run pre-commit" step to README.md installation guide
- Add troubleshooting section to CONTRIBUTING.md for CI failures

## Test plan
- [ ] `research/README.md` renders correctly on GitHub
- [ ] Pre-commit instructions are clear in README.md
- [ ] Troubleshooting table in CONTRIBUTING.md is helpful

Closes #24
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)