### PR TITLE
feat(proofs): Enhance docstrings for Experiment 1 proof

### DIFF
--- a/proofs/QBP/Experiments/Experiment1.lean
+++ b/proofs/QBP/Experiments/Experiment1.lean
@@ -1,13 +1,13 @@
 /-
   Stern-Gerlach Experiment (Experiment 1) - Formal Proofs
 
-  This file contains the formal verification for the Stern-Gerlach experiment,
-  demonstrating that the QBP framework correctly predicts:
-  1. Binary measurement outcomes (±1 only)
-  2. 50/50 probability split for perpendicular states
+  This file contains the formal verification for the Stern-Gerlach experiment.
+  It proves that the QBP framework correctly predicts a 50/50 probability
+  split for a spin-x state measured on the z-axis, aligning with foundational
+  quantum mechanical principles and the empirical results from our Phase 3 analysis.
 
-  Ground Truth Reference: research/01_stern_gerlach_expected_results.md
-  Implementation Reference: experiments/01_stern_gerlach/simulate.py
+  Ground Truth: research/01_stern_gerlach_expected_results.md
+  Analysis: analysis/01_stern_gerlach/
 -/
 import QBP.Basic
 
@@ -15,39 +15,60 @@ namespace QBP.Experiments.SternGerlach
 
 open QBP
 
-/-- The spin-x state: ψ = i (pure quaternion along x-axis) -/
+-- ### SETUP: Define the State and Observable ###
+
+/-- The initial state: a particle with spin oriented along the +x axis.
+    This is represented by the pure quaternion `i`. -/
 def spinXState : Q := SPIN_X
 
-/-- The spin-z observable: O = k (pure quaternion along z-axis) -/
+/-- The measurement: spin along the z-axis.
+    This is represented by the observable quaternion `k`. -/
 def spinZObservable : Q := SPIN_Z
 
-/-- The spin-x state is a pure quaternion -/
+-- ### VERIFICATION: Confirm Properties of State and Observable ###
+
+/-- The spin-x state is a valid pure quaternion as required by the axioms. -/
 theorem spinXState_is_pure : isPureQuaternion spinXState := spin_x_is_pure
 
-/-- The spin-z observable is a pure quaternion -/
+/-- The spin-z observable is a valid pure quaternion as required by the axioms. -/
 theorem spinZObservable_is_pure : isPureQuaternion spinZObservable := spin_z_is_pure
 
-/-- Key theorem: x and z spin directions are orthogonal -/
+-- ### CORE THEOREMS: Deriving the Experimental Outcome ###
+
+/-- **Physical Principle:** The preparation (spin-x) is orthogonal to the measurement (spin-z).
+    **Formal Proof:** This theorem demonstrates that the vector parts of the state and
+    observable quaternions have a dot product of zero. This is the mathematical
+    foundation for the 50/50 probability split. -/
 theorem x_z_orthogonal : vecDot spinXState spinZObservable = 0 := by
   simp [vecDot, spinXState, spinZObservable, SPIN_X, SPIN_Z]
   ring
 
-/-- Main Theorem for Experiment 1:
-    An x-aligned state measured on the z-axis has expectation value 0.
-    This is the formal verification that the QBP framework predicts
-    50/50 probability split for orthogonal measurements. -/
+/-- **Physical Principle:** The average measurement outcome for an x-spin state
+    measured on the z-axis is zero. This occurs because the particle is equally
+    likely to be measured as spin-up or spin-down.
+    **Formal Proof:** This is the main theorem for Experiment 1. It applies the general
+    lemma `expectation_orthogonal_is_zero` to our specific state and observable,
+    proving that their orthogonality necessarily leads to a zero expectation value.
+    This result was empirically validated in our Phase 3 analysis. -/
 theorem expectation_x_measured_z_is_zero :
     expectationValue spinXState spinZObservable = 0 :=
   expectation_orthogonal_is_zero spinXState spinZObservable
     spinXState_is_pure spinZObservable_is_pure x_z_orthogonal
 
-/-- Corollary: P(+1) = 1/2 for x-state measured on z-axis -/
+/-- **Physical Principle:** The probability of measuring "spin-up" (+1) for an
+    x-spin state on the z-axis is exactly 1/2.
+    **Formal Proof:** This corollary directly follows from the zero expectation value.
+    It provides the formal verification for the 50% probability observed in the
+    real-world Stern-Gerlach experiment and our synthetic simulation. -/
 theorem prob_up_x_measured_z_is_half :
     probUp spinXState spinZObservable = 1/2 :=
   prob_up_orthogonal_is_half spinXState spinZObservable
     spinXState_is_pure spinZObservable_is_pure x_z_orthogonal
 
-/-- Corollary: P(-1) = 1/2 for x-state measured on z-axis -/
+/-- **Physical Principle:** The probability of measuring "spin-down" (-1) for an
+    x-spin state on the z-axis is also exactly 1/2.
+    **Formal Proof:** A simple corollary demonstrating the symmetric outcome,
+    derived from the zero expectation value. -/
 theorem prob_down_x_measured_z_is_half :
     probDown spinXState spinZObservable = 1/2 := by
   simp [probDown, expectation_x_measured_z_is_zero]


### PR DESCRIPTION
This PR completes Phase 4 of the Experiment 1 sprint by enhancing the Lean 4 proof with descriptive docstrings that connect the formal mathematics to the physical phenomena.

### Furey & Feynman Review Dialogue

The changes in this PR were driven by a formal review of the proof by the Feynman and Furey personas. The following dialogue captures their reasoning:

**Setting:** *Gemini's internal cognitive space. The validated results from the Phase 3 analysis report are displayed on one screen, showing a near-perfect 50/50 split. The Lean 4 code for `Experiment1.lean` is on another.*

**Feynman:** (Leaning back, arms crossed) "Alright, let's look at this. The simulation works. It gives a 50/50 split, just like popping a coin. The analysis shows it's well within 3-sigma. That's good, that's solid. Now, does this math *actually* represent the physics? Or is it just a clever bit of programming that happens to give the right answer?"

**Furey:** (Eyes tracing the Lean code) "The question is valid, Richard, but let's be precise. The code *is* the math. The simulation is a computational instantiation of the axioms. This proof here is the formal logical chain connecting those axioms to the outcome. The question is whether that chain is rigorous and elegant."

**Feynman:** "Elegant? Who cares about elegant? I want to *understand* it. Let's walk through it. `spinXState` is `i`, `spinZObservable` is `k`. Fine. That's our setup. An x-particle hits a z-magnet."

**Furey:** "Correct. The theorem `x_z_orthogonal` then demonstrates that `vecDot spinXState spinZObservable = 0`. This is the formal statement of orthogonality for these two basis vectors."

**Feynman:** "Right, they're at 90 degrees to each other. `i` and `k` are perpendicular. So the dot product is zero. Simple enough. Then you get to this `expectation_x_measured_z_is_zero` theorem. It says the expectation value is zero. This is the key physical insight! When you measure an x-spin on a z-axis, the *average* result is zero. You get just as many 'up's as 'down's. The proof just says... `expectation_orthogonal_is_zero`. That's a bit of a hand-wave, isn't it? It's hiding the physics."

**Furey:** "It's not a hand-wave; it's an abstraction. We proved the general case in `Basic.lean`. `expectation_orthogonal_is_zero` is a general theorem stating that for any two pure, orthogonal quaternions, the expectation value will be zero. `Experiment1.lean` is now simply applying this general, more powerful theorem to a specific case. This is elegant. We don't want to re-prove the same logic for every pair of orthogonal states."

**Feynman:** "Okay, I see your point. You prove the general tool once, then you use it. Fine. But for someone reading *this* file, the connection isn't immediate. The 'why' is hidden in another file. I want to see the physics right here. At the very least, the docstring for the theorem should explain what it's doing in plain English. 'Main Theorem for Experiment 1' is okay, but it should say *why* it's the main theorem."

**Furey:** "A fair critique. The documentation could be more expressive without sacrificing mathematical precision. The docstring for `expectation_x_measured_z_is_zero` could be improved to explicitly state its physical implication. For instance: 'This theorem formally verifies that the average measurement outcome for a spin-x state measured along the z-axis is zero, confirming the physical principle of superposition leading to a probabilistic 50/50 split.'"

**Feynman:** "Exactly! And the same for `prob_up_x_measured_z_is_half`. The name is descriptive, which is good, but the docstring 'Corollary: P(+1) = 1/2...' is terse. It should say *what that means*. 'This formally proves that the probability of measuring spin-up is exactly 1/2, matching the empirical results of the Stern-Gerlach experiment.' Connect it back to the real world!"

**Furey:** "I agree. The formal proof should not be divorced from its physical interpretation. The purpose of the proof is to build confidence that our mathematical framework accurately models reality. The docstrings are the ideal place to bridge that gap."

### Summary of Changes

Based on the dialogue, the following changes were made:
- The docstrings for all major theorems in `proofs/QBP/Experiments/Experiment1.lean` have been rewritten.
- Each docstring now includes a "Physical Principle" section explaining the concept in plain language.
- Each docstring now includes a "Formal Proof" section explaining the mathematical strategy and its connection to the validated results.
- No changes were made to the logical implementation of the proofs themselves.

This work is now ready for review.

Closes #108