### PR TITLE
docs: Add Acceptance Criteria Verification Protocol to review process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -466,8 +466,10 @@ Before any PR can be merged, the PR **must** contain:
 
 Every review must include a formal **Acceptance Criteria Verification** section that checks the PR against the linked issue's requirements. This ensures PRs don't just receive qualitative approval but actually satisfy what was specified.
 
+**Prerequisites:** Requires GitHub CLI (`gh`) with repository access configured.
+
 **Protocol:**
-1. **Identify linked issues** from PR title, body, and commit messages (`Closes #X`, `Fixes #X`, etc.)
+1. **Identify linked issues** from PR title, body, and commit messages (`Closes #X`, `Fixes #X`, etc.). If no issues are linked, AC verification is N/A (not a failure).
 2. **Fetch issue content** using `gh issue view <number>`
 3. **Extract requirements** — all `- [ ] **AC:**` lines and `Definition of Done` checkboxes
 4. **Verify each criterion:**
@@ -476,9 +478,33 @@ Every review must include a formal **Acceptance Criteria Verification** section 
    - Cite evidence (file:line or explanation)
 5. **Verdict:** PASS (all criteria met) or BLOCKING (any unmet)
 
+**Status Definitions:**
+- **PASS** — Criterion fully satisfied with cited evidence
+- **FAIL** — Criterion not satisfied; requires action before merge
+- **PARTIAL** — Criterion partially satisfied; treated as BLOCKING unless James explicitly approves proceeding
+
 **Template-Agnostic Design:** This protocol parses the actual issue text, not a hardcoded schema. If issue templates evolve, the verification protocol still works — the rigor comes from the process, not the template structure.
 
-**Rule:** Unmet acceptance criteria = BLOCKING. Cannot be deferred to housekeeping without James's explicit approval.
+**Rule:** Unmet acceptance criteria (FAIL or PARTIAL) = BLOCKING. Cannot be deferred to housekeeping without James's explicit approval.
+
+**Example:** For a PR linking to issue #64 (Phase 5: Publication), the AC verification section would look like:
+
+```markdown
+# Acceptance Criteria Verification
+
+**Linked Issue(s):** #64
+
+## Issue #64: Experiment 1 - Phase 5: Publication
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | "Paper section follows physics paper schema" | PASS | `paper/quaternion_physics.md:103-181` follows schema structure |
+| 2 | "Phase 4 formal proofs referenced" | PASS | Line 166 references `SternGerlach.lean` |
+| 3 | "Phase 3 visualizations included" | PARTIAL | References `stern_gerlach_demo.py` but no figure numbers |
+| 4 | "DESIGN_RATIONALE.md updated" | FAIL | No Experiment 1 insights added |
+
+**Verdict:** BLOCKING — Criteria 3-4 require action
+```
 
 ## Issue-Driven Workflow
 


### PR DESCRIPTION
## Summary

Adds a formal Acceptance Criteria Verification Protocol to the review process. This ensures PRs are checked against the linked issue's requirements, not just reviewed qualitatively.

- Reviews must now include AC verification section
- Protocol is template-agnostic (parses actual issue text)
- Unmet criteria = BLOCKING by default

## Changes

**CONTRIBUTING.md:**
- Added AC verification requirement to review steps (1, 2)
- Added step 4: Issue Synthesis (flags BLOCKING items)
- Added full "Acceptance Criteria Verification Protocol" section

## Motivation

During Phase 5 audit, we identified that reviews weren't explicitly checking PRs against issue acceptance criteria. A PR could pass qualitative review but still miss AC requirements.

## Test Plan

- [ ] Review the protocol for clarity and completeness
- [ ] Verify it aligns with existing issue templates
- [ ] Confirm template-agnostic design works with experiment.yml, feature.yml

Closes #144

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)