### PR TITLE
docs: Add prediction classification to ground truth documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,15 +178,18 @@ Every experiment on our roadmap follows a structured 5-phase lifecycle. This ens
 
 **Goal:** Research and document the real-world results we need to match.
 
+**Schema:** See [Ground Truth Schema](docs/schemas/ground_truth_schema.md) for required sections and format.
+
 **Tasks:**
 - Review existing literature and experimental data
 - Define quantitative predictions with error bounds
 - Specify acceptance criteria (e.g., "within 3σ of expected value")
+- Classify predictions as "Validation" (matches QM) or "Novel" (differs from QM)
 - Identify required tools or framework extensions
 
 **Output:** `research/NN_experiment_expected_results.md`
 
-**Exit Criteria:** Ground truth document reviewed and approved.
+**Exit Criteria:** Ground truth document reviewed and approved, with prediction classification complete.
 
 ---
 

--- a/docs/schemas/ground_truth_schema.md
+++ b/docs/schemas/ground_truth_schema.md
@@ -1,0 +1,109 @@
+# Ground Truth Document Schema
+
+This schema defines the structure and requirements for Phase 1 Ground Truth documents (`research/NN_..._expected_results.md`).
+
+## Purpose
+
+Ground truth documents establish the theoretical predictions for an experiment **before** implementation. They serve as:
+1. The specification for Phase 2 implementation
+2. The acceptance criteria for Phase 3 validation
+3. The basis for Phase 4 formal proofs
+
+## Required Sections
+
+### 1. Overview
+- Brief description of the experiment
+- Key result (the main prediction)
+- Cross-references to theory documents
+
+### 2. Physical Situation
+- Real-world setup being modeled
+- What question we're answering
+- Standard QM answer (if known)
+
+### 3. QBP Axioms
+- List the axioms used in the derivation
+- Note any corrections or refinements from previous experiments
+
+### 4. Core Derivation
+- Step-by-step mathematical derivation
+- Key insights and geometric interpretations
+- Code example for verification
+
+### 5. Prediction Classification (REQUIRED)
+
+**This section is mandatory for all ground truth documents.**
+
+Every prediction must be classified as either:
+
+| Type | Definition | Implication |
+|------|------------|-------------|
+| **Validation** | Matches standard QM exactly | Confirms QBP is consistent with known physics |
+| **Novel** | Differs from standard QM | Provides testable distinction between QBP and QM |
+
+**Template:**
+
+```markdown
+## Prediction Classification
+
+| Prediction | Type | Standard QM | Notes |
+|------------|------|-------------|-------|
+| P(+) = cos²(θ/2) | Validation | cos²(θ/2) | Identical to QM |
+
+### Classification Summary
+
+**Validation:** This experiment confirms QBP reproduces standard quantum mechanics
+for [specific scenario]. It does not distinguish QBP from QM.
+
+**Novel predictions (if any):** [None for this experiment / Description of QBP-specific predictions]
+
+### Implications
+
+[What this classification means for QBP's status as a theory]
+```
+
+**Why this matters:** If all QBP predictions match QM exactly, QBP is a reformulation, not a falsifiable alternative theory. Tracking this explicitly helps identify where novel predictions might emerge. See issue #167 for ongoing research into potential QBP divergences.
+
+### 6. Edge Cases
+- Limiting cases (e.g., θ = 0°, 90°, 180°)
+- Physical interpretation of each case
+
+### 7. Quantitative Predictions
+- Table of test values with expected results
+- Statistical acceptance criteria (e.g., 3σ)
+- Detailed acceptance table with μ, σ, and ranges
+
+### 8. Potential Difficulties
+- Known issues or corrections
+- Implementation considerations
+- Numerical precision concerns
+
+### 9. Connection to Future Experiments
+- How this experiment relates to later work
+- What foundations it establishes
+
+### 10. Summary
+- Key insights
+- What Phase 2 will test
+
+### 11. Phase 2 Acceptance Criteria
+- Specific criteria for implementation phase
+- What must pass for Phase 2 to complete
+
+### 12. References
+- Academic citations
+- Internal document references
+
+## File Naming
+
+Ground truth documents follow the pattern:
+```
+research/NN_experiment_name_expected_results.md
+```
+
+Where `NN` is the two-digit experiment number (01, 02, etc.).
+
+## Examples
+
+- `research/01_expected_results.md` (Stern-Gerlach)
+- `research/02_angle_dependent_expected_results.md` (Angle-Dependent Measurement)

--- a/research/01_stern_gerlach_expected_results.md
+++ b/research/01_stern_gerlach_expected_results.md
@@ -45,7 +45,26 @@ This formal derivation shows that the QBP framework correctly predicts a 50/50 p
 
 ---
 
-## 4. Quantitative Predictions & Acceptance Criteria
+## 4. Prediction Classification
+
+| Prediction | Type | Standard QM | Notes |
+|------------|------|-------------|-------|
+| P(+) = P(-) = 0.5 for orthogonal states | Validation | 0.5 | Identical to QM |
+| Binary outcomes only (+1, -1) | Validation | Same | Spin quantization |
+
+### Classification Summary
+
+**Validation:** This experiment confirms QBP reproduces standard quantum mechanics for the orthogonal state/measurement case (spin-x prepared, spin-z measured). It does not distinguish QBP from QM.
+
+**Novel predictions:** None for this experiment. The 50/50 split for orthogonal states is a foundational QM result that QBP must reproduce to be viable.
+
+### Implications
+
+Experiment 01 establishes that QBP is *consistent* with QM for the simplest spin measurement case. This is necessary but not sufficient for QBP to be a distinct physical theory. See #167 for ongoing research into where QBP predictions might diverge from QM.
+
+---
+
+## 5. Quantitative Predictions & Acceptance Criteria
 
 Our `experiments/01_stern_gerlach/simulate.py` script will be considered successful if it meets the following criteria, which directly correspond to the real-world experimental results and our formal derivation.
 
@@ -71,7 +90,7 @@ To ensure statistically significant results, our synthetic experiments will adhe
 
 ---
 
-## 5. References
+## 6. References
 
 1.  Gerlach, W.; Stern, O. (1922). "Der experimentelle Nachweis der Richtungsquantelung im Magnetfeld". *Zeitschrift für Physik*. 9 (1): 349–352.
 2.  Griffiths, David J.; Schroeter, Darrell F. (2018). *Introduction to Quantum Mechanics*. Cambridge University Press.

--- a/research/02_angle_dependent_expected_results.md
+++ b/research/02_angle_dependent_expected_results.md
@@ -391,7 +391,29 @@ All must pass the 3σ acceptance criterion (see §7.3).
 
 ---
 
-## 11. Phase 2 Acceptance Criteria
+## 11. Prediction Classification
+
+| Prediction | Type | Standard QM | Notes |
+|------------|------|-------------|-------|
+| P(+) = cos²(θ/2) = (1 + cos θ)/2 | Validation | cos²(θ/2) | Identical to QM |
+| P(-) = sin²(θ/2) = (1 - cos θ)/2 | Validation | sin²(θ/2) | Identical to QM |
+| Deterministic at θ=0°, 180° | Validation | Same | Aligned/anti-aligned cases |
+
+### Classification Summary
+
+**Validation:** This experiment confirms QBP reproduces standard quantum mechanics for angle-dependent spin measurement. The formula P(+) = cos²(θ/2) is identical to the standard QM result derived from spinor theory.
+
+**Novel predictions:** None for this experiment. The angle-dependent probability formula is a textbook QM result that QBP must reproduce to be viable.
+
+### Implications
+
+Experiment 02 extends Experiment 01's validation to arbitrary angles. Together, they establish that QBP correctly handles all single-particle spin-1/2 measurements. This is *mathematically necessary* because quaternions (ℍ) are isomorphic to the Pauli algebra underlying SU(2).
+
+For QBP to make novel predictions, we must look beyond single-particle systems — possibly to entanglement (Experiment 05: Bell's Theorem), multi-particle statistics, or regimes where octonion structure becomes relevant. See #167 for ongoing research.
+
+---
+
+## 12. Phase 2 Acceptance Criteria
 
 The following criteria must be met for Phase 2 (Implementation) to pass:
 
@@ -403,7 +425,7 @@ The following criteria must be met for Phase 2 (Implementation) to pass:
 
 ---
 
-## 12. References
+## 13. References
 
 1. Hamilton, W.R. (1844). "On Quaternions". *Proceedings of the Royal Irish Academy*.
 2. Sakurai, J.J. (1994). *Modern Quantum Mechanics*. Addison-Wesley.


### PR DESCRIPTION
## Summary

Adds mandatory "Prediction Classification" section to ground truth documents to explicitly distinguish between validation predictions (match QM) and novel predictions (differ from QM).

**Closes #170**

## Changes

### New Schema
- `docs/schemas/ground_truth_schema.md` — Full schema for ground truth documents including required sections and prediction classification template

### Updated Ground Truth Documents
- `research/01_stern_gerlach_expected_results.md` — Added Section 4 (Prediction Classification)
- `research/02_angle_dependent_expected_results.md` — Added Section 11 (Prediction Classification)

### Updated Process Documentation
- `CONTRIBUTING.md` — Phase 1 now references schema and includes classification task

## Classification Results

| Experiment | Prediction | Type |
|------------|-----------|------|
| 01 Stern-Gerlach | P(+) = P(-) = 0.5 | Validation |
| 02 Angle-Dependent | P(+) = cos²(θ/2) | Validation |

Both experiments reproduce known QM results exactly. This is expected for single-particle systems due to the isomorphism between quaternions and the Pauli algebra.

## Acceptance Criteria

From #170:
- [x] **AC:** Update docs/schemas/ with prediction classification guidance
- [x] **AC:** Define "Validation" vs "Novel" prediction categories
- [x] **AC:** Retroactively update Experiments 01 and 02 ground truth documents
- [x] **AC:** Ensure future ground truth documents include this classification (via schema)

## Test Plan

- [ ] Verify schema is comprehensive and clear
- [ ] Confirm classification sections are accurate
- [ ] Check CONTRIBUTING.md reference works

---

🤖 Generated with [Claude Code](https://claude.ai/code) (Housekeeping Mode)