### PR TITLE
feat: Implement angle-dependent measurement (Sprint 2 Phase 2)

### DIFF
--- a/experiments/02_angle_dependent/simulate.py
+++ b/experiments/02_angle_dependent/simulate.py
@@ -1,0 +1,217 @@
+# experiments/02_angle_dependent/simulate.py
+"""
+Angle-Dependent Measurement Simulation
+
+This experiment validates the QBP prediction that the probability of measuring
+spin-up along an axis at angle theta from the particle's spin direction follows:
+
+    P(+) = (1 + cos(theta))/2 = cos²(theta/2)
+
+This is the "Malus's law" for spin-1/2 measurements, a fundamental test of the
+quaternionic framework's ability to reproduce quantum mechanical predictions.
+
+Physical setup:
+- Prepare particle with spin at angle θ from z-axis (in x-z plane)
+- Measure spin along z-axis
+- Record outcome (+1 or -1)
+- Repeat N times and verify statistics match QM prediction
+
+Ground truth: research/02_angle_dependent_expected_results.md
+"""
+
+import numpy as np
+import pandas as pd
+import sys
+import os
+from datetime import datetime
+
+# Add the project root to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src import qphysics
+
+# Test angles as specified in ground truth document
+TEST_ANGLES = [0, 30, 45, 60, 90, 120, 135, 150, 180]  # degrees
+
+# Number of particles per angle (1M for statistical significance, per ground truth §7.2)
+NUM_PARTICLES = 1_000_000
+
+
+def expected_probability(theta_deg: float) -> float:
+    """
+    Calculate expected P(+) for angle theta.
+
+    From QBP axioms: P(+) = (1 + cos(θ))/2
+    Equivalent to QM: P(+) = cos²(θ/2)
+    """
+    theta_rad = np.radians(theta_deg)
+    return (1 + np.cos(theta_rad)) / 2
+
+
+def calculate_sigma(p: float, n: int) -> float:
+    """
+    Calculate standard deviation for binomial distribution.
+
+    σ = sqrt(n * p * (1-p))
+
+    Note: σ = 0 for p = 0 or p = 1 (deterministic cases)
+    """
+    if p == 0 or p == 1:
+        return 0.0
+    return np.sqrt(n * p * (1 - p))
+
+
+def run_simulation(num_particles: int = NUM_PARTICLES, seed: int = 42) -> pd.DataFrame:
+    """
+    Run angle-dependent measurement simulation for all test angles.
+
+    Args:
+        num_particles: Number of particles to simulate per angle.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        DataFrame with results for all angles.
+    """
+    print("=" * 70)
+    print("ANGLE-DEPENDENT MEASUREMENT SIMULATION")
+    print("Experiment 02 - Sprint 2 Phase 2")
+    print("=" * 70)
+    print(f"Particles per angle: {num_particles:,}")
+    print(f"Test angles: {TEST_ANGLES}")
+    print(f"Random seed: {seed}")
+    print("-" * 70)
+
+    # Observable: measurement along z-axis
+    observable = qphysics.SPIN_Z
+
+    results = []
+
+    for i, angle_deg in enumerate(TEST_ANGLES):
+        theta_rad = np.radians(angle_deg)
+
+        # Create state tilted by theta from z-axis toward x-axis
+        # Using the new convenience function
+        state = qphysics.create_tilted_state(theta_rad)
+
+        # Use different seed for each angle to ensure statistical independence
+        angle_seed = seed + i if seed is not None else None
+
+        # Run batch measurement
+        outcomes = qphysics.measure_batch(state, observable, num_particles, angle_seed)
+
+        # Calculate statistics
+        num_up = np.sum(outcomes == 1)
+        num_down = np.sum(outcomes == -1)
+        measured_prob = num_up / num_particles
+        expected_prob = expected_probability(angle_deg)
+        sigma = calculate_sigma(expected_prob, num_particles)
+
+        # Calculate deviation in sigma units
+        if sigma > 0:
+            deviation_sigma = abs(measured_prob - expected_prob) / (sigma / num_particles)
+            # Actually: deviation should be in terms of count, not probability
+            deviation_sigma = abs(num_up - expected_prob * num_particles) / sigma if sigma > 0 else 0
+        else:
+            # Deterministic case: any deviation is infinite sigma
+            deviation_sigma = 0 if num_up == int(expected_prob * num_particles) else float('inf')
+
+        # Determine pass/fail (3σ criterion)
+        passed = deviation_sigma <= 3.0
+
+        results.append({
+            'angle_deg': angle_deg,
+            'angle_rad': theta_rad,
+            'num_particles': num_particles,
+            'num_up': num_up,
+            'num_down': num_down,
+            'measured_prob': measured_prob,
+            'expected_prob': expected_prob,
+            'sigma': sigma,
+            'deviation_sigma': deviation_sigma,
+            'passed': passed
+        })
+
+        status = "PASS" if passed else "FAIL"
+        print(f"θ = {angle_deg:3d}°: P(+) expected={expected_prob:.4f}, "
+              f"measured={measured_prob:.6f}, deviation={deviation_sigma:.2f}σ [{status}]")
+
+    print("-" * 70)
+
+    df = pd.DataFrame(results)
+    return df
+
+
+def save_results(df: pd.DataFrame, output_dir: str = "results/02_angle_dependent") -> str:
+    """
+    Save simulation results to timestamped CSV file.
+
+    Args:
+        df: DataFrame with simulation results.
+        output_dir: Directory for output files.
+
+    Returns:
+        Path to saved CSV file.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    csv_path = os.path.join(output_dir, f"simulation_results_{timestamp}.csv")
+    df.to_csv(csv_path, index=False)
+    return csv_path
+
+
+def print_summary(df: pd.DataFrame):
+    """Print summary of simulation results."""
+    print("\n" + "=" * 70)
+    print("SUMMARY")
+    print("=" * 70)
+
+    all_passed = df['passed'].all()
+    max_deviation = df['deviation_sigma'].replace([np.inf], np.nan).max()
+
+    print(f"\nTotal angles tested: {len(df)}")
+    print(f"All tests passed: {'YES' if all_passed else 'NO'}")
+    print(f"Maximum deviation: {max_deviation:.2f}σ")
+
+    # Check edge cases specifically
+    edge_cases = df[df['angle_deg'].isin([0, 90, 180])]
+    print("\nEdge case verification:")
+    for _, row in edge_cases.iterrows():
+        angle = row['angle_deg']
+        expected = row['expected_prob']
+        measured = row['measured_prob']
+        print(f"  θ={angle:3d}°: expected P(+)={expected:.1f}, measured={measured:.6f}")
+
+    if all_passed:
+        print("\n" + "=" * 70)
+        print("EXPERIMENT PASSED: All angles within 3σ of QM prediction")
+        print("QBP framework correctly predicts P(+) = cos²(θ/2)")
+        print("=" * 70)
+    else:
+        print("\n" + "=" * 70)
+        print("EXPERIMENT FAILED: Some angles exceed 3σ deviation")
+        failed = df[~df['passed']]
+        for _, row in failed.iterrows():
+            print(f"  FAILED: θ={row['angle_deg']}° ({row['deviation_sigma']:.2f}σ)")
+        print("=" * 70)
+
+
+def main():
+    """Main entry point for the simulation."""
+    print(f"\nStarting simulation at {datetime.now().isoformat()}\n")
+
+    # Run simulation
+    df = run_simulation()
+
+    # Save results
+    csv_path = save_results(df)
+    print(f"\nResults saved to: {csv_path}")
+
+    # Print summary
+    print_summary(df)
+
+    # Return exit code based on pass/fail
+    return 0 if df['passed'].all() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/results/02_angle_dependent/simulation_results_2026-02-06_15-00-02.csv
+++ b/results/02_angle_dependent/simulation_results_2026-02-06_15-00-02.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01977031e00b4195aa8a95ad166a759f3a25943dfe7b82658960f2be6fe77b4e
+size 964

--- a/tests/physics/test_qphysics_rotation.py
+++ b/tests/physics/test_qphysics_rotation.py
@@ -1,0 +1,237 @@
+# tests/physics/test_qphysics_rotation.py
+"""
+Tests for the rotation functions in qphysics.py
+
+These tests verify:
+1. create_rotation() produces correct rotation quaternions
+2. rotate_observable() correctly rotates measurement axes
+3. rotate_state() correctly rotates quantum states
+4. create_tilted_state() produces states at correct angles
+
+Physical validation: Rotation quaternions must satisfy:
+- Half-angle formula: q = cos(θ/2) + sin(θ/2) * axis
+- Unit norm: |q| = 1
+- Rotation formula: v' = q * v * q⁻¹ rotates v by θ around axis
+"""
+
+import numpy as np
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src import qphysics
+
+
+class TestCreateRotation:
+    """Tests for the create_rotation function."""
+
+    def test_identity_rotation(self):
+        """Rotation by 0 should give identity quaternion."""
+        q = qphysics.create_rotation(0, [0, 0, 1])
+        # Identity quaternion is (1, 0, 0, 0)
+        assert np.isclose(q.w, 1.0, atol=1e-10)
+        assert np.isclose(q.x, 0.0, atol=1e-10)
+        assert np.isclose(q.y, 0.0, atol=1e-10)
+        assert np.isclose(q.z, 0.0, atol=1e-10)
+
+    def test_90_degree_rotation_z(self):
+        """90° rotation around z-axis."""
+        q = qphysics.create_rotation(np.pi / 2, [0, 0, 1])
+        # q = cos(45°) + sin(45°) * k = (√2/2, 0, 0, √2/2)
+        sqrt2_2 = np.sqrt(2) / 2
+        assert np.isclose(q.w, sqrt2_2, atol=1e-10)
+        assert np.isclose(q.x, 0.0, atol=1e-10)
+        assert np.isclose(q.y, 0.0, atol=1e-10)
+        assert np.isclose(q.z, sqrt2_2, atol=1e-10)
+
+    def test_180_degree_rotation(self):
+        """180° rotation around y-axis."""
+        q = qphysics.create_rotation(np.pi, [0, 1, 0])
+        # q = cos(90°) + sin(90°) * j = (0, 0, 1, 0)
+        assert np.isclose(q.w, 0.0, atol=1e-10)
+        assert np.isclose(q.x, 0.0, atol=1e-10)
+        assert np.isclose(q.y, 1.0, atol=1e-10)
+        assert np.isclose(q.z, 0.0, atol=1e-10)
+
+    def test_360_degree_rotation_gives_minus_identity(self):
+        """360° rotation gives -1 (SU(2) double cover)."""
+        q = qphysics.create_rotation(2 * np.pi, [0, 0, 1])
+        # After 360°, q = -1 = (-1, 0, 0, 0)
+        assert np.isclose(q.w, -1.0, atol=1e-10)
+        assert np.isclose(q.x, 0.0, atol=1e-10)
+        assert np.isclose(q.y, 0.0, atol=1e-10)
+        assert np.isclose(q.z, 0.0, atol=1e-10)
+
+    def test_unit_norm(self):
+        """Rotation quaternion should have unit norm."""
+        test_cases = [
+            (np.pi / 4, [1, 0, 0]),
+            (np.pi / 3, [0, 1, 0]),
+            (np.pi / 6, [0, 0, 1]),
+            (2.5, [1, 1, 1]),  # Arbitrary angle and axis
+        ]
+        for angle, axis in test_cases:
+            q = qphysics.create_rotation(angle, axis)
+            norm = np.sqrt(q.w**2 + q.x**2 + q.y**2 + q.z**2)
+            assert np.isclose(norm, 1.0, atol=1e-10), f"Failed for angle={angle}, axis={axis}"
+
+    def test_axis_normalization(self):
+        """Non-unit axis should be normalized automatically."""
+        q1 = qphysics.create_rotation(np.pi / 2, [0, 0, 1])
+        q2 = qphysics.create_rotation(np.pi / 2, [0, 0, 5])  # Same direction, different magnitude
+        assert np.isclose(q1.w, q2.w, atol=1e-10)
+        assert np.isclose(q1.z, q2.z, atol=1e-10)
+
+    def test_zero_axis_raises(self):
+        """Zero axis should raise ValueError."""
+        with pytest.raises(ValueError, match="cannot be zero"):
+            qphysics.create_rotation(np.pi / 2, [0, 0, 0])
+
+
+class TestRotateObservable:
+    """Tests for the rotate_observable function."""
+
+    def test_no_rotation(self):
+        """Zero rotation leaves observable unchanged."""
+        O = qphysics.SPIN_Z
+        O_rotated = qphysics.rotate_observable(O, 0, [0, 1, 0])
+        assert np.isclose(O_rotated.x, O.x, atol=1e-10)
+        assert np.isclose(O_rotated.y, O.y, atol=1e-10)
+        assert np.isclose(O_rotated.z, O.z, atol=1e-10)
+
+    def test_90_degree_rotation_z_to_x(self):
+        """Rotating SPIN_Z by 90° around y-axis should give SPIN_X."""
+        O_rotated = qphysics.rotate_observable(qphysics.SPIN_Z, np.pi / 2, [0, 1, 0])
+        # Z rotated 90° around Y → X
+        assert np.isclose(O_rotated.x, 1.0, atol=1e-10)
+        assert np.isclose(O_rotated.y, 0.0, atol=1e-10)
+        assert np.isclose(O_rotated.z, 0.0, atol=1e-10)
+
+    def test_90_degree_rotation_x_to_y(self):
+        """Rotating SPIN_X by 90° around z-axis should give SPIN_Y."""
+        O_rotated = qphysics.rotate_observable(qphysics.SPIN_X, np.pi / 2, [0, 0, 1])
+        # X rotated 90° around Z → Y
+        assert np.isclose(O_rotated.x, 0.0, atol=1e-10)
+        assert np.isclose(O_rotated.y, 1.0, atol=1e-10)
+        assert np.isclose(O_rotated.z, 0.0, atol=1e-10)
+
+    def test_180_degree_rotation_reverses(self):
+        """180° rotation reverses the observable direction."""
+        O_rotated = qphysics.rotate_observable(qphysics.SPIN_Z, np.pi, [1, 0, 0])
+        # Z rotated 180° around X → -Z
+        assert np.isclose(O_rotated.x, 0.0, atol=1e-10)
+        assert np.isclose(O_rotated.y, 0.0, atol=1e-10)
+        assert np.isclose(O_rotated.z, -1.0, atol=1e-10)
+
+    def test_result_is_pure_quaternion(self):
+        """Rotated observable should have zero real part."""
+        O_rotated = qphysics.rotate_observable(qphysics.SPIN_Z, 1.234, [1, 1, 0])
+        assert np.isclose(O_rotated.w, 0.0, atol=1e-10)
+
+
+class TestRotateState:
+    """Tests for the rotate_state function."""
+
+    def test_rotate_z_state_by_90_around_y(self):
+        """Rotating z-aligned state by 90° around y gives x-aligned state."""
+        psi = qphysics.create_state_from_vector([0, 0, 1])  # |+z⟩
+        psi_rotated = qphysics.rotate_state(psi, np.pi / 2, [0, 1, 0])
+        # Should now point along x
+        vec = qphysics.get_state_vector(psi_rotated)
+        assert np.isclose(vec[0], 1.0, atol=1e-10)  # x
+        assert np.isclose(vec[1], 0.0, atol=1e-10)  # y
+        assert np.isclose(vec[2], 0.0, atol=1e-10)  # z
+
+    def test_rotated_state_is_normalized(self):
+        """Rotated state should remain normalized."""
+        psi = qphysics.create_state_from_vector([1, 1, 1])
+        psi_rotated = qphysics.rotate_state(psi, 1.5, [1, 0, 1])
+        norm = psi_rotated.norm()
+        assert np.isclose(norm, 1.0, atol=1e-10)
+
+    def test_rotated_state_is_pure(self):
+        """Rotated state should remain a pure quaternion."""
+        psi = qphysics.create_state_from_vector([1, 0, 0])
+        psi_rotated = qphysics.rotate_state(psi, np.pi / 3, [0, 1, 0])
+        assert np.isclose(psi_rotated.w, 0.0, atol=1e-10)
+
+
+class TestCreateTiltedState:
+    """Tests for the create_tilted_state convenience function."""
+
+    def test_zero_tilt_gives_z_state(self):
+        """θ=0 should give state along +z."""
+        psi = qphysics.create_tilted_state(0)
+        vec = qphysics.get_state_vector(psi)
+        assert np.isclose(vec[0], 0.0, atol=1e-10)  # x
+        assert np.isclose(vec[1], 0.0, atol=1e-10)  # y
+        assert np.isclose(vec[2], 1.0, atol=1e-10)  # z
+
+    def test_90_tilt_gives_x_state(self):
+        """θ=90° should give state along +x."""
+        psi = qphysics.create_tilted_state(np.pi / 2)
+        vec = qphysics.get_state_vector(psi)
+        assert np.isclose(vec[0], 1.0, atol=1e-10)  # x
+        assert np.isclose(vec[1], 0.0, atol=1e-10)  # y
+        assert np.isclose(vec[2], 0.0, atol=1e-10)  # z
+
+    def test_180_tilt_gives_minus_z_state(self):
+        """θ=180° should give state along -z."""
+        psi = qphysics.create_tilted_state(np.pi)
+        vec = qphysics.get_state_vector(psi)
+        assert np.isclose(vec[0], 0.0, atol=1e-10)  # x
+        assert np.isclose(vec[1], 0.0, atol=1e-10)  # y
+        assert np.isclose(vec[2], -1.0, atol=1e-10)  # z
+
+    def test_60_tilt_gives_correct_components(self):
+        """θ=60° should give (sin 60°, 0, cos 60°) = (√3/2, 0, 0.5)."""
+        psi = qphysics.create_tilted_state(np.pi / 3)
+        vec = qphysics.get_state_vector(psi)
+        assert np.isclose(vec[0], np.sqrt(3) / 2, atol=1e-10)  # x = sin(60°)
+        assert np.isclose(vec[1], 0.0, atol=1e-10)  # y
+        assert np.isclose(vec[2], 0.5, atol=1e-10)  # z = cos(60°)
+
+    def test_tilted_state_is_normalized(self):
+        """Tilted state should be a unit quaternion."""
+        for theta in [0, np.pi / 6, np.pi / 4, np.pi / 3, np.pi / 2, np.pi]:
+            psi = qphysics.create_tilted_state(theta)
+            norm = psi.norm()
+            assert np.isclose(norm, 1.0, atol=1e-10), f"Failed for theta={theta}"
+
+
+class TestRotationAndMeasurement:
+    """Integration tests: rotation functions with measurement."""
+
+    def test_tilted_state_expectation_value(self):
+        """Expectation value of tilted state against z should equal cos(θ)."""
+        test_angles = [0, 30, 45, 60, 90, 120, 150, 180]
+
+        for angle_deg in test_angles:
+            theta = np.radians(angle_deg)
+            psi = qphysics.create_tilted_state(theta)
+            exp_val = qphysics.expectation_value(psi, qphysics.SPIN_Z)
+
+            expected = np.cos(theta)
+            assert np.isclose(exp_val, expected, atol=1e-10), (
+                f"Failed at {angle_deg}°: got {exp_val}, expected {expected}"
+            )
+
+    def test_rotated_observable_equivalent_to_tilted_state(self):
+        """Rotating observable should give same expectation as tilting state."""
+        theta = np.pi / 4  # 45°
+
+        # Method 1: Tilt state, measure along z
+        psi_tilted = qphysics.create_tilted_state(theta)
+        exp1 = qphysics.expectation_value(psi_tilted, qphysics.SPIN_Z)
+
+        # Method 2: Keep state along z, rotate observable
+        psi_z = qphysics.create_state_from_vector([0, 0, 1])
+        O_rotated = qphysics.rotate_observable(qphysics.SPIN_Z, theta, [0, 1, 0])
+        exp2 = qphysics.expectation_value(psi_z, O_rotated)
+
+        # Both should give cos(θ)
+        assert np.isclose(exp1, np.cos(theta), atol=1e-10)
+        assert np.isclose(exp2, np.cos(theta), atol=1e-10)
+        assert np.isclose(exp1, exp2, atol=1e-10)


### PR DESCRIPTION
## Summary

Implements Sprint 2 Phase 2: angle-dependent measurement simulation for Experiment 02.

**Issue:** #161

## Changes

### qphysics.py Extensions
- `create_rotation(theta, axis)` — Create rotation quaternion using half-angle formula
- `rotate_observable(O, theta, axis)` — Rotate measurement axis via q·O·q⁻¹
- `rotate_state(psi, theta, axis)` — Rotate quantum state
- `create_tilted_state(theta)` — Convenience function for tilted states in x-z plane
- **Bug fix:** Normalization now uses `np.abs(q)` instead of `q.norm()` (squared norm)

### New Simulation
- `experiments/02_angle_dependent/simulate.py`
- Tests 9 angles: 0°, 30°, 45°, 60°, 90°, 120°, 135°, 150°, 180°
- 1M particles per angle
- CSV output to `results/02_angle_dependent/`

### New Tests
- `tests/physics/test_qphysics_rotation.py` — 22 tests for rotation functions

## Results

All angles pass within 3σ of P(+) = cos²(θ/2):

| Angle | Expected | Measured | Deviation |
|-------|----------|----------|-----------|
| 0° | 1.0000 | 1.000000 | 0.00σ |
| 90° | 0.5000 | 0.499125 | 1.75σ |
| 180° | 0.0000 | 0.000000 | 0.00σ |

Maximum deviation: 1.75σ (well within 3σ acceptance)

## Acceptance Criteria

- [x] All new and existing tests pass (56 tests)
- [x] Simulation generates timestamped CSV output
- [x] Results match P(+) = cos²(θ/2) within 3σ
- [x] Edge cases pass: θ=0° → P(+)=1, θ=180° → P(+)=0

## Test plan

- [x] `pytest tests/physics/` — All 40 physics tests pass
- [x] `python3 experiments/02_angle_dependent/simulate.py` — Full simulation passes

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)