### PR TITLE
ci: Add dependency check for /libs/ independence (#126)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,40 @@ jobs:
       - name: Validate experiment numbers
         run: python scripts/validate_experiment_numbers.py
 
+  libs-dependency-check:
+    name: Library Independence Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check libs/ for QBP dependencies
+        run: |
+          # Skip if libs/ directory doesn't exist
+          if [ ! -d "libs" ]; then
+            echo "No libs/ directory found - check passes (nothing to validate)"
+            exit 0
+          fi
+
+          # Check for prohibited imports in .lean files under libs/
+          # Libraries must not depend on QBP-specific definitions
+          echo "Checking libs/ for prohibited QBP imports..."
+
+          VIOLATIONS=$(grep -r -l -E "^import (QBP|proofs)" libs/ --include="*.lean" 2>/dev/null || true)
+
+          if [ -n "$VIOLATIONS" ]; then
+            echo "ERROR: Found QBP-specific imports in libs/"
+            echo "Libraries in /libs/ must remain general-purpose and must not import from proofs/QBP/"
+            echo ""
+            echo "Files with violations:"
+            echo "$VIOLATIONS"
+            echo ""
+            echo "Details:"
+            grep -r -n -E "^import (QBP|proofs)" libs/ --include="*.lean"
+            exit 1
+          fi
+
+          echo "All clear - no QBP-specific imports found in libs/"
+
   code-quality:
     name: Code Quality Scan
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,6 +310,8 @@ During Phase 4a, proofs may require Lean 4 capabilities that do not exist in Mat
 
 **Key principle:** Libraries must remain general-purpose. They must not import from `proofs/QBP/` or depend on any QBP-specific definitions. If other Lean users could benefit from the capability, it belongs in `/libs/`.
 
+> **CI enforcement:** The `libs-dependency-check` job in CI automatically scans any `.lean` files under `/libs/` for prohibited imports (`import QBP` or `import proofs`). PRs that introduce such dependencies will fail the check.
+
 ##### Phase 4b: Proof Review
 
 **Owner:** Claude


### PR DESCRIPTION
## Summary

Adds CI enforcement for the library independence constraint: libraries in `/libs/` must not import from `proofs/QBP/`.

## Changes

### CI Job Added
- `libs-dependency-check` in `.github/workflows/ci.yml`
- Scans `.lean` files under `libs/` for prohibited imports
- Checks for `import QBP` or `import proofs`
- Fails if violations found
- Passes if `libs/` doesn't exist (future-proof)

### Documentation
- Added CI enforcement note to CONTRIBUTING.md (Phase 4a section)

## Why Now?

The `libs/` directory doesn't exist yet, but this check is proactive:
- Ready to catch violations when first library is created
- No cost to run (exits immediately if no libs/)
- Prevents accidental dependency introduction

## Test plan

- [ ] CI job runs and passes (no libs/ directory)
- [ ] Check documented in CONTRIBUTING.md

**Review tier:** Tier 2 (CI/infrastructure)

Closes #126

🤖 Generated with [Claude Code](https://claude.ai/claude-code)