### PR TITLE
docs(process): Add Sprint Retrospective as formal sprint phase

### DIFF
--- a/.github/ISSUE_TEMPLATE/sprint_retrospective.yml
+++ b/.github/ISSUE_TEMPLATE/sprint_retrospective.yml
@@ -1,0 +1,129 @@
+name: Sprint Retrospective
+description: Formal retrospective after completing a sprint's Theory Refinement phase
+title: "Sprint [N] Retrospective: [Experiment Name]"
+labels: ["retrospective", "process"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Sprint Retrospective
+
+        Complete this retrospective after Theory Refinement merges, before beginning the next sprint.
+        This is a learning gate, not a compliance gate.
+
+  - type: input
+    id: sprint_number
+    attributes:
+      label: Sprint Number
+      description: Which sprint is this retrospective for?
+      placeholder: "1"
+    validations:
+      required: true
+
+  - type: input
+    id: experiment
+    attributes:
+      label: Experiment
+      description: Which experiment(s) were completed this sprint?
+      placeholder: "01 Stern-Gerlach, 01b Angle-Dependent"
+    validations:
+      required: true
+
+  - type: textarea
+    id: critical_path
+    attributes:
+      label: "1. Did we follow the critical path this sprint?"
+      description: Were phases completed in order? Did we stay focused?
+      placeholder: |
+        Yes/No
+
+        Details...
+    validations:
+      required: true
+
+  - type: textarea
+    id: deviations
+    attributes:
+      label: "2. Where did we deviate?"
+      description: List any diversions, out-of-order work, or scope changes
+      placeholder: |
+        - Diversion 1: [description]
+        - Diversion 2: [description]
+    validations:
+      required: true
+
+  - type: textarea
+    id: cost
+    attributes:
+      label: "3. What was the cost of deviation?"
+      description: Time lost, rework required, context switching overhead
+      placeholder: |
+        - Time: ~X sessions on diversions
+        - Rework: [any rework needed]
+        - Positive tradeoffs: [if any]
+    validations:
+      required: true
+
+  - type: textarea
+    id: commitment
+    attributes:
+      label: "4. What is our commitment for next sprint?"
+      description: Simple, concrete commitment to improve next sprint
+      placeholder: |
+        1. [Commitment 1]
+        2. [Commitment 2]
+    validations:
+      required: true
+
+  - type: textarea
+    id: procedural_learnings
+    attributes:
+      label: "5. Procedural learnings"
+      description: What operational details did we learn? (validation frequencies, edge case handling, etc.)
+      placeholder: |
+        - Learned that X should be done every Y
+        - Edge case Z is handled by doing W
+        - Validation script needs to run before commits
+    validations:
+      required: true
+
+  - type: textarea
+    id: doc_updates
+    attributes:
+      label: "6. Documentation updates needed"
+      description: Which docs need updating based on learnings?
+      placeholder: |
+        - [ ] Update CONTRIBUTING.md with [specific section]
+        - [ ] Update docs/technical/X.md with [learnings]
+        - [ ] Add runbook for [process]
+    validations:
+      required: true
+
+  - type: textarea
+    id: process_refinements
+    attributes:
+      label: "7. Process refinements"
+      description: What should change in our workflows or guidelines?
+      placeholder: |
+        - Change review tier for X from Tier 2 to Tier 3
+        - Add CI check for Y
+        - Modify Herschel check to include Z
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: All must be checked before closing this issue
+      options:
+        - label: All 7 questions answered with concrete examples
+          required: true
+        - label: Documentation updates from section 6 completed (or issues created)
+          required: true
+        - label: Process refinements from section 7 applied (or issues created)
+          required: true
+        - label: SPRINT_STATUS.md updated with retrospective summary
+          required: true
+        - label: Ready to begin next sprint
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,16 +30,44 @@ Our project operates on a `Sprint -> Refine -> Sprint` cycle, which is the engin
 
 This ensures our theory evolves based on our experimental results.
 
-### Sprint Retrospective Gate
+### Sprint Retrospective
 
-Before beginning Sprint N+1, a brief retrospective must be documented in `SPRINT_STATUS.md` answering:
+After Theory Refinement completes, a formal Sprint Retrospective issue must be created and completed before beginning the next sprint. The retrospective is **tracked as a GitHub issue** (not just prose in SPRINT_STATUS.md).
 
-1.  Did we follow the critical path this sprint?
-2.  If not, where did we deviate?
-3.  What was the *cost* of that deviation?
-4.  What is our simple, agreed-upon commitment for the next sprint?
+**Each sprint's issue set includes:**
 
-This is not a compliance gate — it is a learning gate. The goal is to connect the pain of deviation to the action that was skipped, building institutional memory that makes the process feel valuable rather than bureaucratic.
+| Phase | Purpose |
+|-------|---------|
+| Phase 1: Ground Truth | Establish predictions |
+| Phase 2: Implementation | Build and validate |
+| Phase 3: Visualization | Visualize results |
+| Phase 4: Formal Verification | Prove correctness |
+| Phase 5: Publication | Document findings |
+| Theory Refinement | Extend theory |
+| **Sprint Retrospective** | **Capture learnings** |
+
+**The retrospective issue must answer:**
+
+1. Did we follow the critical path this sprint?
+2. If not, where did we deviate?
+3. What was the *cost* of that deviation?
+4. What is our simple, agreed-upon commitment for the next sprint?
+
+**Additionally, the retrospective captures:**
+
+5. **Procedural learnings** — What operational details did we learn? (e.g., validation frequencies, edge case handling)
+6. **Documentation updates** — Which docs need updating based on learnings?
+7. **Process refinements** — What should change in CONTRIBUTING.md or workflows?
+
+This is not a compliance gate — it is a learning gate. The goal is to connect the pain of deviation to the action that was skipped, and to backport operational learnings into documentation, building institutional memory.
+
+**Retrospective workflow:**
+1. Create retrospective issue after Theory Refinement PR merges
+2. Answer all questions with concrete examples
+3. Update relevant documentation with learnings
+4. Update SPRINT_STATUS.md with summary
+5. Close retrospective issue
+6. Begin next sprint
 
 ---
 


### PR DESCRIPTION
## Summary

Formalizes the Sprint Retrospective as a tracked GitHub issue, making it part of the sprint issue set alongside Phases 1-5 and Theory Refinement.

## Changes

### CONTRIBUTING.md
- Retrospective is now tracked as a GitHub issue (not just prose)
- Added to sprint issue set table
- Expanded questions to include:
  - Procedural learnings (validation frequencies, edge case handling)
  - Documentation updates needed
  - Process refinements
- Documented retrospective workflow

### New Template
- `.github/ISSUE_TEMPLATE/sprint_retrospective.yml` — Structured retrospective form

## Why This Matters

Procedural learnings from implementation (like proof graph validation details) need a formal capture point. The retrospective:
1. Captures what we learned
2. Updates documentation with learnings
3. Builds institutional memory

## Test plan

- [ ] Retrospective template renders correctly
- [ ] CONTRIBUTING.md changes are coherent

**Review tier:** Tier 1 (documentation)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)