### PR TITLE
docs(proofs): Document Lean toolchain requirements

### DIFF
--- a/proofs/README.md
+++ b/proofs/README.md
@@ -2,6 +2,17 @@
 
 This directory contains Lean 4 formal proofs for Quaternion-Based Physics experiments.
 
+## Toolchain Requirements
+
+| Component | Version | Notes |
+|-----------|---------|-------|
+| Lean 4 | v4.28.0-rc1 | Specified in `lean-toolchain` |
+| Lake | 5.0.0 | Ships with Lean |
+| Mathlib4 | Compatible with Lean 4.28 | Locked in `lake-manifest.json` |
+| elan | Latest | Required to manage Lean versions |
+
+**Important:** Always use `elan` to manage Lean installations. The `lean-toolchain` file ensures the correct version is used automatically. Running `lake` directly with a system-installed Lean (e.g., v4.15.0) will cause build errors.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary

- Add Toolchain Requirements section to `proofs/README.md`
- Documents working Lean 4 + mathlib version combination
- Clarifies that elan is required (system Lean causes build errors)

## Root Cause

Issue #213 reported `lake build` failing with mathlib errors. The root cause was running `lake` with a system-installed Lean (v4.15.0) instead of the toolchain-specified version (v4.28.0-rc1).

The toolchain was already correctly configured — the fix is documentation to prevent future confusion.

## Verification

```bash
cd proofs
elan show          # Confirms v4.28.0-rc1 active
lake exe cache get # Downloads prebuilt mathlib (5 min)
lake build         # Succeeds: 2390 jobs
```

Both `QBP.Experiments.SternGerlach` and `QBP.Experiments.AngleDependent` compile cleanly.

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)