### PR TITLE
docs: Housekeeping & research issue lifecycle integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -791,11 +791,11 @@ Not all work is sprint phases. Housekeeping, research, and infrastructure issues
 ```
 Is it blocking the next sprint's critical path?
   YES → Sprint field = Research Sprint NR (scoped, critical path)
-  NO  → Sprint field = House Keeping (single backlog for all types)
+  NO  → Sprint field = "House Keeping" (single backlog for all types)
     Then label by type:
-      Code/docs/process/tooling → label: housekeeping
-      Physics/math/theory       → label: type: research
-      Infrastructure/CI/tooling → label: type: infra
+      Code/docs/process/local tooling  → label: housekeeping
+      Physics/math/theory              → label: type: research
+      Shared CI/CD/infra               → label: type: infra
 ```
 
 One backlog sprint ("House Keeping") for all non-critical-path work. Labels differentiate type. This avoids categorization paralysis for hybrid issues and provides a single place to look.

--- a/docs/workflows/housekeeping_mode_workflow.md
+++ b/docs/workflows/housekeeping_mode_workflow.md
@@ -215,16 +215,7 @@ Housekeeping issues are created in 3 contexts:
 
 ### Creation Checklist
 
-Every housekeeping issue must have:
-
-1. **Title:** "Housekeeping: \<descriptive title\>"
-2. **Body:** Origin (which PR/review/observation), Action items, AC checkboxes
-3. **Label:** `housekeeping`
-4. **Project board:** Add to "QBP Research Lifecycle"
-5. **Sprint field:** Set to "House Keeping"
-6. **Status:** "Todo"
-
-After any PR review cycle (Step 4 — Issues Identified), every deferred item **must** become a GitHub issue with this checklist applied. No "we'll get to it" without a tracked issue.
+Follow the **[Housekeeping Issue Creation Checklist](../../CONTRIBUTING.md#housekeeping-issue-creation-checklist)** in CONTRIBUTING.md. Every housekeeping issue needs: title convention, body with origin and AC, `housekeeping` label, board placement, Sprint = "House Keeping", Status = "Todo".
 
 ### Prioritization
 

--- a/docs/workflows/research_mode_workflow.md
+++ b/docs/workflows/research_mode_workflow.md
@@ -425,14 +425,7 @@ Research issues follow a structured lifecycle integrated with the project board.
 
 ### Creation Checklist
 
-Every research issue must have:
-
-1. **Title:** "Research: \<descriptive question\>"
-2. **Body:** Origin, Research question, Expected deliverables, AC checkboxes
-3. **Label:** `type: research`
-4. **Project board:** Add to "QBP Research Lifecycle"
-5. **Sprint field:** "House Keeping" (if unscoped) or "Research Sprint NR" (if blocking critical path)
-6. **Status:** "Todo"
+Follow the **[Research Issue Creation Checklist](../../CONTRIBUTING.md#research-issue-creation-checklist)** in CONTRIBUTING.md. Every research issue needs: title convention, body with research question and AC, `type: research` label, board placement, Sprint = "House Keeping" (or Research Sprint NR if blocking), Status = "Todo".
 
 ### Triage
 


### PR DESCRIPTION
## Summary

Closes #348

- Adds "Non-Critical-Path Issue Lifecycle" section to CONTRIBUTING.md with decision tree, housekeeping checklist, research checklist, backlog triggers, and completion rules
- Adds "Issue Lifecycle" sections to both `housekeeping_mode_workflow.md` and `research_mode_workflow.md`
- Fixed labels and Sprint fields on 13 existing issues (board-only changes, not in diff)

## Board Changes (not in diff)

| Issue | Label Fix | Sprint Field |
|-------|-----------|-------------|
| #227, #228, #229 | `enhancement` → `housekeeping` | Set to House Keeping |
| #238 | Added `type: infra` | Set to House Keeping |
| #296 | Added `type: infra` | Set to House Keeping |
| #317 | Removed `type: research` | Set to House Keeping |
| #337 | `type: experiment` → `housekeeping` | Set to House Keeping |
| #341 | `type: infra` → `housekeeping` | Set to House Keeping |
| #325, #326, #335, #329, #346 | Already correct | Set to House Keeping |

## Test plan

- [ ] Verify CONTRIBUTING.md renders correctly on GitHub
- [ ] Verify workflow docs render correctly
- [ ] Spot-check board: issues in House Keeping sprint with correct labels
- [ ] Confirm no issues left without Sprint field in the backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)