### PR TITLE
chore: Update SPRINT_STATUS for PR #361 merge + FAULT-S3-003

### DIFF
--- a/SPRINT_STATUS.md
+++ b/SPRINT_STATUS.md
@@ -9,8 +9,8 @@
 ## Current Position
 
 - **Active Sprint:** Sprint 3 (Experiment 03: Double-Slit)
-- **Lifecycle Stage:** Phase 2/3 Rework (Far-Field) — near-field Phases 1-3 complete, but BPM results are near-field only (~32 nm propagation). Far-field capability required for experimentally comparable predictions.
-- **Next Critical-Path Action:** Phase 2 Rework (#359, far-field BPM + Fraunhofer FFT) → Phase 3 Rework (#360, far-field visualization) → Phase 4 → Phase 5 → Theory Refinement → Retrospective
+- **Lifecycle Stage:** Phase 3 Rework (Far-Field Visualization) — near-field Phases 1-3 complete, far-field BPM+FFT complete (PR #361 merged). Far-field visualization remaining.
+- **Next Critical-Path Action:** Phase 3 Rework (#360, far-field visualization) → Phase 4 → Phase 5 → Theory Refinement → Retrospective
 
 > **Sprint 3 Phase 1 Complete:** PR #285 merged 2026-02-13 after 5 review rounds (10 total reviews). Full quaternionic dynamics with Adler decay. Empirical Anchor framework introduced. Issue #22 closed.
 
@@ -27,7 +27,7 @@
 - [x] Phase 1: Ground Truth (#22) — CLOSED 2026-02-13. PR #285 merged. 5 review rounds. Empirical Anchor framework introduced.
 - [x] Phase 2: Implementation (#36) — CLOSED. PR #287 (original), PR #333 (SI compliance redo), PR #343 (v3 results format rework). SI-compliant BPM with self-describing output. **Near-field only (~32 nm).**
 - [x] Phase 3: Visualization (#342, v3 rework) — CLOSED. PR #355 merged 2026-02-15. Near-field hero plots + RESULTS.md. PR #357 (Panel C normalization fix).
-- [ ] **Phase 2 Rework: Far-Field (#359)** — Hybrid BPM + Fraunhofer FFT to produce experimentally comparable far-field predictions. Near-field BPM captures quaternionic coupling in slit region; FFT propagates to detector plane. ~200 lines new code.
+- [x] **Phase 2 Rework: Far-Field (#359)** — CLOSED 2026-02-17. PR #361 merged. Hybrid BPM + Fraunhofer FFT. V(U₁=0)=0.655, V(U₁=max)=0.600 (~8.5% reduction).
 - [ ] **Phase 3 Rework: Far-Field Visualization (#360)** — Far-field fringe overlay, zoomed fringes, residual plots, V(U₁) at far-field. Comparison with analytical Fraunhofer baseline.
 - [ ] Phase 4: Formal Verification (#56)
   - [ ] 4a: Formal Proof (#259)
@@ -63,7 +63,7 @@ Original phases struck through; sprint restarts after research:
 2. ~~Phase 2 (#36) — blocked by research~~
 3. ~~Phase 3 (#37) — PR #318 closed without merge~~
 
-**New critical path (post-PIVOT-S3-001):** #319 → #320 → #322 → Phase 2 → Phase 3 → **Phase 2 Rework (#359) → Phase 3 Rework (#360)** → Phase 4 → Phase 5 → Theory Refinement → Retrospective
+**New critical path (post-PIVOT-S3-001):** #319 → #320 → #322 → Phase 2 → Phase 3 → ~~Phase 2 Rework (#359)~~ → **Phase 3 Rework (#360)** → Phase 4 → Phase 5 → Theory Refinement → Retrospective
 
 > **Far-Field Rework (2026-02-16):** Near-field BPM propagates ~32 nm — far too short for Fraunhofer conditions. All Sprint 3 results so far are near-field only (V ≈ 0.553 baseline vs analytical V = 1.0). To produce experimentally comparable predictions, we're adding a hybrid approach: BPM through the slit region (where quaternionic coupling acts), then Fraunhofer FFT to the far-field detector plane. This is ~200 lines of new simulation code (#359) plus new visualization (#360). See `docs/Possible Future Experiments/001_far_field_double_slit.md` for the scientific motivation.
 
@@ -248,6 +248,19 @@ During PR #362 integration, Herschel began executing the integration plan (which
 **Process update:**
 - **RULE: "Execute the integration plan" does NOT imply merge authorization.** The merge step always requires James's explicit "merge it" command, even when embedded in a broader integration instruction.
 - Integration plans should separate pre-merge preparation from the merge action itself.
+
+### FAULT-S3-003: Stale SPRINT_STATUS caused wrong Herschel check guidance (2026-02-17)
+
+**What happened:**
+Herschel check reported #342 (near-field Phase 3 Visualization) as the next critical-path action, but #342 was already CLOSED. The actual next step was merging PR #361 (#359 far-field BPM+FFT). Time was spent planning the wrong task before James caught the error.
+
+**Root cause:** SPRINT_STATUS.md was not updated when #342 closed (PR #355 merged 2026-02-15). The "Next Critical-Path Action" line was stale.
+
+**Process update:**
+- **RULE: When merging a PR that closes a critical-path issue, ALWAYS update SPRINT_STATUS.md in the same session** — specifically the "Next Critical-Path Action" line and closure checklist.
+- Herschel check should cross-reference the first unchecked closure checklist item, not just read the prose line.
+
+> Full entry: [`docs/process_violation_log.md`](docs/process_violation_log.md) — FAULT-S3-003
 
 ---
 

--- a/docs/process_violation_log.md
+++ b/docs/process_violation_log.md
@@ -34,6 +34,18 @@ This log records all process violations across sprints. Each entry documents wha
 | **Fixes applied** | 1. `git reset --soft HEAD~1` to undo the commit. 2. Changes moved to `feature/359-far-field-bpm-fft` branch. 3. This log entry. |
 | **Process update** | Reinforced: ALL changes go through branch -> PR -> CI -> merge. No exceptions for "quick" changes. |
 
+### FAULT-S3-003: Stale SPRINT_STATUS caused wrong Herschel check guidance (2026-02-17)
+
+| Field | Detail |
+|-------|--------|
+| **Date** | 2026-02-17 |
+| **Sprint/Phase** | Sprint 3 / Phase 3 Rework (Far-Field) |
+| **What happened** | Herschel check reported #342 (near-field Phase 3 Visualization) as the next critical-path action. James started Focus Mode planning for #342, but it was already CLOSED. The actual next step was merging PR #361 (#359 far-field BPM+FFT). Time was spent planning the wrong task before James caught the error. |
+| **Root cause (technical)** | SPRINT_STATUS.md was not updated when #342 was closed (PR #355 merged 2026-02-15). The closure checklist still showed #342 as checked, but the "Next Critical-Path Action" line was stale. |
+| **Root cause (process)** | Herschel check trusts SPRINT_STATUS.md as single source of truth, but there's no automated verification that the critical path line matches actual issue states. When #342 closed in a different session, the status file wasn't updated. |
+| **Fixes applied** | 1. SPRINT_STATUS.md updated: #359 checked off, critical path corrected to #360. 2. This log entry. |
+| **Process update** | Rule added: When merging a PR that closes a critical-path issue, ALWAYS update SPRINT_STATUS.md in the same session — specifically the "Next Critical-Path Action" line and closure checklist. Herschel check should cross-reference the first unchecked item on the closure checklist, not just read the prose line. |
+
 ---
 
 ## Template


### PR DESCRIPTION
## Summary
- Marks #359 (far-field BPM+FFT) as CLOSED in Sprint 3 closure checklist (PR #361 merged)
- Updates critical path: next action is **#360** (far-field visualization)
- Documents **FAULT-S3-003**: stale SPRINT_STATUS.md caused Herschel check to give wrong guidance (pointed to already-closed #342 instead of PR #361)
- Adds process rule: always update SPRINT_STATUS.md when closing critical-path issues

## Files Changed
- `SPRINT_STATUS.md` — closure checklist + critical path + fault log
- `docs/process_violation_log.md` — FAULT-S3-003 full entry

Operational update — no code changes. Tier 0 (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)