### PR TITLE
fix: Use CURRENT symlink for results discovery (#366)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,12 @@ jobs:
       - name: Validate CURRENT symlinks resolve
         run: |
           # Every results/*/CURRENT symlink must point to an existing directory
+          shopt -s nullglob
           FAIL=0
+          COUNT=0
           for link in results/*/CURRENT; do
             [ -L "$link" ] || continue
+            COUNT=$((COUNT + 1))
             if [ ! -d "$link" ]; then
               echo "BROKEN: $link -> $(readlink "$link")"
               FAIL=1
@@ -117,6 +120,11 @@ jobs:
               echo "OK: $link -> $(readlink "$link")"
             fi
           done
+          if [ "$COUNT" -eq 0 ]; then
+            echo "ERROR: No CURRENT symlinks found to validate"
+            exit 1
+          fi
+          echo "Validated $COUNT symlink(s)"
           exit $FAIL
 
   libs-dependency-check:

--- a/analysis/03_double_slit/analyze.py
+++ b/analysis/03_double_slit/analyze.py
@@ -63,15 +63,18 @@ def load_data(
         metadata_dict may contain key 'farfield_qbp_df' with the far-field QBP DataFrame.
     """
     # Use CURRENT symlink if available, fall back to v3/ for backward compat
+    # Note: os.path.isdir() follows symlinks, so this works for both symlinks and dirs
     current_dir = os.path.join(results_dir, "CURRENT")
-    v3_dir = (
+    versioned_dir = (
         current_dir if os.path.isdir(current_dir) else os.path.join(results_dir, "v3")
     )
 
     # --- Try versioned format first ---
-    v3_nearfield = sorted(glob.glob(os.path.join(v3_dir, "results_nearfield_*.csv")))
-    if v3_nearfield:
-        latest_nf = max(v3_nearfield, key=os.path.getctime)
+    versioned_nearfield = sorted(
+        glob.glob(os.path.join(versioned_dir, "results_nearfield_*.csv"))
+    )
+    if versioned_nearfield:
+        latest_nf = max(versioned_nearfield, key=os.path.getctime)
         timestamp = (
             os.path.basename(latest_nf)
             .replace("results_nearfield_", "")
@@ -82,7 +85,7 @@ def load_data(
         # Map regime → scenario for backward compat
         nf_df["scenario"] = "C"
 
-        farfield_path = os.path.join(v3_dir, f"results_farfield_{timestamp}.csv")
+        farfield_path = os.path.join(versioned_dir, f"results_farfield_{timestamp}.csv")
         if os.path.exists(farfield_path):
             ff_df = pd.read_csv(farfield_path)
             # farfield has 'scenario' column already (A/B)
@@ -97,12 +100,12 @@ def load_data(
         else:
             fringe_df = nf_df
 
-        decay_path = os.path.join(v3_dir, f"decay_{timestamp}.csv")
+        decay_path = os.path.join(versioned_dir, f"decay_{timestamp}.csv")
         decay_df = (
             pd.read_csv(decay_path) if os.path.exists(decay_path) else pd.DataFrame()
         )
 
-        summary_path = os.path.join(v3_dir, f"summary_{timestamp}.csv")
+        summary_path = os.path.join(versioned_dir, f"summary_{timestamp}.csv")
         summary_df = (
             pd.read_csv(summary_path)
             if os.path.exists(summary_path)
@@ -118,17 +121,19 @@ def load_data(
             }
             summary_df["scenario"] = summary_df["regime"].map(regime_to_scenario)
 
-        meta_path = os.path.join(v3_dir, f"metadata_{timestamp}.json")
+        meta_path = os.path.join(versioned_dir, f"metadata_{timestamp}.json")
         metadata = {}
         if os.path.exists(meta_path):
             with open(meta_path) as f:
                 metadata = json.load(f)
 
         # Far-field QBP (BPM + Fraunhofer FFT) — optional
-        ff_qbp_path = os.path.join(v3_dir, f"results_farfield_qbp_{timestamp}.csv")
+        ff_qbp_path = os.path.join(
+            versioned_dir, f"results_farfield_qbp_{timestamp}.csv"
+        )
         if os.path.exists(ff_qbp_path):
             metadata["farfield_qbp_df"] = pd.read_csv(ff_qbp_path)
-            print(f"Loaded v3 format from {v3_dir}")
+            print(f"Loaded versioned format from {versioned_dir}")
             print(f"  Nearfield:     {os.path.basename(latest_nf)}")
             print(f"  Farfield:      results_farfield_{timestamp}.csv")
             print(f"  Farfield QBP:  results_farfield_qbp_{timestamp}.csv")
@@ -136,7 +141,7 @@ def load_data(
             print(f"  Summary:       summary_{timestamp}.csv")
             print(f"  Metadata:      metadata_{timestamp}.json")
         else:
-            print(f"Loaded v3 format from {v3_dir}")
+            print(f"Loaded versioned format from {versioned_dir}")
             print(f"  Nearfield:  {os.path.basename(latest_nf)}")
             print(f"  Farfield:   results_farfield_{timestamp}.csv")
             print(f"  Decay:      decay_{timestamp}.csv")


### PR DESCRIPTION
## Summary
- `analyze.py` and `double_slit_viz.py` now discover data via `results/03_double_slit/CURRENT/` symlink, falling back to `v3/` for backward compat
- CI smoke test added to validate all `CURRENT` symlinks resolve correctly
- No hardcoded version paths remain in consumer code

Closes #366

## Test plan
- [ ] `python3 analysis/03_double_slit/analyze.py --no-open` still loads data
- [ ] CI symlink validation step passes
- [ ] VPython viz loads data correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)