### PR TITLE
feat: Phase 4d — Verified differential testing for Double-Slit (#301)

### DIFF
--- a/proofs/QBP/Oracle/FloatCompute.lean
+++ b/proofs/QBP/Oracle/FloatCompute.lean
@@ -104,4 +104,8 @@ def floatCouplingDecomposition (u0 u1 a0 b0 a1 b1 : Float) : QFloat :=
     (mirrors QBP.Experiments.DoubleSlit.decayConstant) -/
 def floatDecayConstant (u1 d : Float) : Float := u1 * d
 
+/-- Decay length: L_decay = 1/κ
+    (mirrors QBP.Experiments.DoubleSlit.decayLength) -/
+def floatDecayLength (κ : Float) : Float := 1.0 / κ
+
 end QBP.Oracle

--- a/proofs/QBP/Oracle/Main.lean
+++ b/proofs/QBP/Oracle/Main.lean
@@ -96,73 +96,86 @@ def generateTestCases : List String := Id.run do
       (floatExpectationValue psi obs)]
 
   -- Experiment 03: Double-Slit test vectors
+  -- All cases include input fields so the Python harness can reconstruct computations.
   -- (pi already bound above on line 43)
 
   -- Coupling decomposition test: (2 + 3j)(1 + 0.5i + 0.7j + 0.3k)
   let coupResult := floatCouplingDecomposition 2.0 3.0 1.0 0.5 0.7 0.3
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"coupling_decomp\", " ++
+    s!"\"U0\": 2.0, \"U1\": 3.0, \"a0\": 1.0, \"b0\": 0.5, \"a1\": 0.7, \"b1\": 0.3, " ++
     s!"\"re\": {floatToJson coupResult.re}, \"imI\": {floatToJson coupResult.imI}, " ++
     s!"\"imJ\": {floatToJson coupResult.imJ}, \"imK\": {floatToJson coupResult.imK}}"]
 
   -- Coupling decomposition with purely real ψ₀, ψ₁ (mirrors coupling_decomposition_real)
   let coupReal := floatCouplingDecomposition 2.0 3.0 1.0 0.0 0.7 0.0
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"coupling_decomp_real\", " ++
+    s!"\"U0\": 2.0, \"U1\": 3.0, \"a0\": 1.0, \"b0\": 0.0, \"a1\": 0.7, \"b1\": 0.0, " ++
     s!"\"re\": {floatToJson coupReal.re}, \"imI\": {floatToJson coupReal.imI}, " ++
     s!"\"imJ\": {floatToJson coupReal.imJ}, \"imK\": {floatToJson coupReal.imK}}"]
 
   -- Coupling with U₁ = 0 (mirrors coupling_decouples_U1_zero)
   let coupDecoupled := floatCouplingDecomposition 2.0 0.0 1.0 0.5 0.7 0.3
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"coupling_decoupled\", " ++
+    s!"\"U0\": 2.0, \"U1\": 0.0, \"a0\": 1.0, \"b0\": 0.5, \"a1\": 0.7, \"b1\": 0.3, " ++
     s!"\"re\": {floatToJson coupDecoupled.re}, \"imI\": {floatToJson coupDecoupled.imI}, " ++
     s!"\"imJ\": {floatToJson coupDecoupled.imJ}, \"imK\": {floatToJson coupDecoupled.imK}}"]
 
   -- Norm squared of symplectic form: ψ = (0.6, 0.8, 0.3, 0.4)
-  let sympPsi := floatSympForm 0.6 0.8 0.3 0.4
-  let nsq := floatNormSqSymp sympPsi
+  let nsq := floatNormSqSymp (floatSympForm 0.6 0.8 0.3 0.4)
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"normSq_sympForm\", " ++
+    s!"\"re0\": 0.6, \"im0\": 0.8, \"re1\": 0.3, \"im1\": 0.4, " ++
     s!"\"normSq\": {floatToJson nsq}}"]
 
-  -- Visibility: perfect interference (Imin = 0), no interference (Imax = Imin)
+  -- Visibility: perfect interference (Imin = 0), no interference (Imax = Imin), partial
   let visA := floatVisibility 1.0 0.0
   let visB := floatVisibility 1.0 1.0
   let visPartial := floatVisibility 1.0 0.3
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"visibility_perfect\", " ++
-    s!"\"visibility\": {floatToJson visA}}"]
+    s!"\"Imax\": 1.0, \"Imin\": 0.0, \"visibility\": {floatToJson visA}}"]
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"visibility_none\", " ++
-    s!"\"visibility\": {floatToJson visB}}"]
+    s!"\"Imax\": 1.0, \"Imin\": 1.0, \"visibility\": {floatToJson visB}}"]
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"visibility_partial\", " ++
-    s!"\"visibility\": {floatToJson visPartial}}"]
+    s!"\"Imax\": 1.0, \"Imin\": 0.3, \"visibility\": {floatToJson visPartial}}"]
 
   -- Fraunhofer intensity at maximum and minimum
   -- d=1e-6, λ=500e-9, L=1.0, I₀=1.0
-  let iAtMax := floatFraunhoferIntensity 1.0 1.0e-6 500.0e-9 1.0 0.0  -- x=0 is a maximum
+  let iAtMax := floatFraunhoferIntensity 1.0 1.0e-6 500.0e-9 1.0 0.0
   let spacing := floatFringeSpacing 500.0e-9 1.0 1.0e-6
   let iAtMin := floatFraunhoferIntensity 1.0 1.0e-6 500.0e-9 1.0 (spacing / 2.0)
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"fraunhofer_at_max\", " ++
+    s!"\"I0\": 1.0, \"d\": 0.000001, \"lam\": 5e-07, \"L\": 1.0, \"x\": 0.0, " ++
     s!"\"intensity\": {floatToJson iAtMax}}"]
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"fraunhofer_at_min\", " ++
+    s!"\"I0\": 1.0, \"d\": 0.000001, \"lam\": 5e-07, \"L\": 1.0, \"x\": {floatToJson (spacing / 2.0)}, " ++
     s!"\"intensity\": {floatToJson iAtMin}}"]
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"fringe_spacing\", " ++
+    s!"\"lam\": 5e-07, \"L\": 1.0, \"d\": 0.000001, " ++
     s!"\"spacing\": {floatToJson spacing}}"]
 
   -- Quaternionic fraction
-  let eta0 := floatQuatFraction 1.0 0.0    -- pure complex: η = 0
-  let etaHalf := floatQuatFraction 0.5 0.5  -- equal split: η = 0.5
-  let eta1 := floatQuatFraction 0.0 1.0    -- pure quaternionic: η = 1
+  let eta0 := floatQuatFraction 1.0 0.0
+  let etaHalf := floatQuatFraction 0.5 0.5
+  let eta1 := floatQuatFraction 0.0 1.0
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"eta_zero\", " ++
-    s!"\"eta\": {floatToJson eta0}}"]
+    s!"\"normSq0\": 1.0, \"normSq1\": 0.0, \"eta\": {floatToJson eta0}}"]
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"eta_half\", " ++
-    s!"\"eta\": {floatToJson etaHalf}}"]
+    s!"\"normSq0\": 0.5, \"normSq1\": 0.5, \"eta\": {floatToJson etaHalf}}"]
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"eta_one\", " ++
-    s!"\"eta\": {floatToJson eta1}}"]
+    s!"\"normSq0\": 0.0, \"normSq1\": 1.0, \"eta\": {floatToJson eta1}}"]
 
-  -- Decay constant scaling
+  -- Decay constant and decay length
   let kappa1 := floatDecayConstant 1.0 1.0e-6
   let kappa2 := floatDecayConstant 2.0 1.0e-6
+  let decayLen1 := floatDecayLength kappa1
+  let decayLen2 := floatDecayLength kappa2
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"decay_constant_1\", " ++
-    s!"\"kappa\": {floatToJson kappa1}}"]
+    s!"\"U1\": 1.0, \"d_sep\": 0.000001, \"kappa\": {floatToJson kappa1}}"]
   cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"decay_constant_2\", " ++
-    s!"\"kappa\": {floatToJson kappa2}}"]
+    s!"\"U1\": 2.0, \"d_sep\": 0.000001, \"kappa\": {floatToJson kappa2}}"]
+  cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"decay_length_1\", " ++
+    s!"\"kappa_in\": {floatToJson kappa1}, \"decay_length\": {floatToJson decayLen1}}"]
+  cases := cases ++ [s!"  \{\"experiment\": \"03\", \"label\": \"decay_length_2\", " ++
+    s!"\"kappa_in\": {floatToJson kappa2}, \"decay_length\": {floatToJson decayLen2}}"]
 
   return cases
 

--- a/src/qphysics.py
+++ b/src/qphysics.py
@@ -387,3 +387,82 @@ def angle_between_states(psi: np.quaternion, observable: np.quaternion) -> float
     # Clamp to [-1, 1] for numerical safety
     dot = max(-1.0, min(1.0, dot))
     return float(np.arccos(dot))
+
+
+# --- Experiment 03: Double-Slit Scalar Functions ---
+# These mirror the Lean Float oracle (QBP.Oracle.FloatCompute) exactly.
+# Used by Phase 4d differential testing to verify implementation correctness.
+
+import math as _math
+
+
+def coupling_decomposition(
+    U0: float, U1: float, a0: float, b0: float, a1: float, b1: float
+) -> dict[str, float]:
+    """Quaternionic coupling: (U₀ + U₁j)(ψ₀ + ψ₁j).
+
+    Mirrors QBP.Experiments.DoubleSlit.coupling_decomposition.
+    """
+    return {
+        "re": U0 * a0 - U1 * a1,
+        "imI": U0 * b0 + U1 * b1,
+        "imJ": U0 * a1 + U1 * a0,
+        "imK": U0 * b1 - U1 * b0,
+    }
+
+
+def normSq_sympForm(re0: float, im0: float, re1: float, im1: float) -> float:
+    """Norm squared of symplectic form: ||ψ₀||² + ||ψ₁||².
+
+    Mirrors QBP.Experiments.DoubleSlit.normSq_sympForm.
+    """
+    return re0**2 + im0**2 + re1**2 + im1**2
+
+
+def visibility(Imax: float, Imin: float) -> float:
+    """Fringe visibility: V = (Imax - Imin) / (Imax + Imin).
+
+    Mirrors QBP.Experiments.DoubleSlit.visibility.
+    """
+    return (Imax - Imin) / (Imax + Imin)
+
+
+def quat_fraction(normSq0: float, normSq1: float) -> float:
+    """Quaternionic fraction: η = ||ψ₁||² / (||ψ₀||² + ||ψ₁||²).
+
+    Mirrors QBP.Experiments.DoubleSlit.quatFraction.
+    """
+    return normSq1 / (normSq0 + normSq1)
+
+
+def fraunhofer_intensity(I0: float, d: float, lam: float, L: float, x: float) -> float:
+    """Fraunhofer intensity: I₀ · cos²(π·d·x/(λ·L)).
+
+    Mirrors QBP.Optics.Fraunhofer.fraunhoferIntensity.
+    """
+    arg = _math.pi * d * x / (lam * L)
+    return I0 * _math.cos(arg) ** 2
+
+
+def fringe_spacing(lam: float, L: float, d: float) -> float:
+    """Fringe spacing: Δx = λ·L/d.
+
+    Mirrors QBP.Optics.Fraunhofer.fringeSpacing.
+    """
+    return lam * L / d
+
+
+def decay_constant(U1: float, d: float) -> float:
+    """Decay constant: κ = U₁ · d.
+
+    Mirrors QBP.Experiments.DoubleSlit.decayConstant.
+    """
+    return U1 * d
+
+
+def decay_length(kappa: float) -> float:
+    """Decay length: L_decay = 1/κ.
+
+    Mirrors QBP.Experiments.DoubleSlit.decayLength.
+    """
+    return 1.0 / kappa

--- a/src/qphysics.py
+++ b/src/qphysics.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import math as _math
+
 import numpy as np
 import quaternion
 
@@ -392,8 +394,7 @@ def angle_between_states(psi: np.quaternion, observable: np.quaternion) -> float
 # --- Experiment 03: Double-Slit Scalar Functions ---
 # These mirror the Lean Float oracle (QBP.Oracle.FloatCompute) exactly.
 # Used by Phase 4d differential testing to verify implementation correctness.
-
-import math as _math
+# Naming convention: function names match the Lean definitions for traceability.
 
 
 def coupling_decomposition(
@@ -438,6 +439,9 @@ def quat_fraction(normSq0: float, normSq1: float) -> float:
 def fraunhofer_intensity(I0: float, d: float, lam: float, L: float, x: float) -> float:
     """Fraunhofer intensity: I₀ · cos²(π·d·x/(λ·L)).
 
+    Models the two-slit interference pattern only (cos² fringes from path
+    difference). Does not include the single-slit diffraction envelope (sinc²).
+
     Mirrors QBP.Optics.Fraunhofer.fraunhoferIntensity.
     """
     arg = _math.pi * d * x / (lam * L)
@@ -454,6 +458,10 @@ def fringe_spacing(lam: float, L: float, d: float) -> float:
 
 def decay_constant(U1: float, d: float) -> float:
     """Decay constant: κ = U₁ · d.
+
+    U₁ is the quaternionic coupling strength (dimensionless in code units),
+    d is the slit separation. The product κ is a dimensionless tunneling
+    exponent controlling the decay of quaternionic interference.
 
     Mirrors QBP.Experiments.DoubleSlit.decayConstant.
     """

--- a/tests/oracle_predictions.json
+++ b/tests/oracle_predictions.json
@@ -18,5 +18,22 @@
   {"experiment": "3d", "label": "3d_oblique_2", "theta_s": 0.785398, "phi_s": 3.141593, "theta_o": 2.356194, "phi_o": 0.000000, "prob_up": 0.000000, "prob_down": 1.000000, "expectation": -1.000000},
   {"experiment": "3d", "label": "3d_oblique_3", "theta_s": 2.094395, "phi_s": 0.785398, "theta_o": 0.523599, "phi_o": 3.926991, "prob_up": 0.066987, "prob_down": 0.933013, "expectation": -0.866025},
   {"experiment": "3d", "label": "3d_same_dir", "theta_s": 0.785398, "phi_s": 1.047198, "theta_o": 0.785398, "phi_o": 1.047198, "prob_up": 1.000000, "prob_down": 0.000000, "expectation": 1.000000},
-  {"experiment": "3d", "label": "3d_opposite", "theta_s": 1.047198, "phi_s": 0.785398, "theta_o": 2.094395, "phi_o": 3.926991, "prob_up": 0.000000, "prob_down": 1.000000, "expectation": -1.000000}
+  {"experiment": "3d", "label": "3d_opposite", "theta_s": 1.047198, "phi_s": 0.785398, "theta_o": 2.094395, "phi_o": 3.926991, "prob_up": 0.000000, "prob_down": 1.000000, "expectation": -1.000000},
+  {"experiment": "03", "label": "coupling_decomp", "U0": 2.0, "U1": 3.0, "a0": 1.0, "b0": 0.5, "a1": 0.7, "b1": 0.3, "re": -0.100000, "imI": 1.900000, "imJ": 4.400000, "imK": -0.900000},
+  {"experiment": "03", "label": "coupling_decomp_real", "U0": 2.0, "U1": 3.0, "a0": 1.0, "b0": 0.0, "a1": 0.7, "b1": 0.0, "re": -0.100000, "imI": 0.000000, "imJ": 4.400000, "imK": 0.000000},
+  {"experiment": "03", "label": "coupling_decoupled", "U0": 2.0, "U1": 0.0, "a0": 1.0, "b0": 0.5, "a1": 0.7, "b1": 0.3, "re": 2.000000, "imI": 1.000000, "imJ": 1.400000, "imK": 0.600000},
+  {"experiment": "03", "label": "normSq_sympForm", "re0": 0.6, "im0": 0.8, "re1": 0.3, "im1": 0.4, "normSq": 1.250000},
+  {"experiment": "03", "label": "visibility_perfect", "Imax": 1.0, "Imin": 0.0, "visibility": 1.000000},
+  {"experiment": "03", "label": "visibility_none", "Imax": 1.0, "Imin": 1.0, "visibility": 0.000000},
+  {"experiment": "03", "label": "visibility_partial", "Imax": 1.0, "Imin": 0.3, "visibility": 0.538462},
+  {"experiment": "03", "label": "fraunhofer_at_max", "I0": 1.0, "d": 0.000001, "lam": 5e-07, "L": 1.0, "x": 0.0, "intensity": 1.000000},
+  {"experiment": "03", "label": "fraunhofer_at_min", "I0": 1.0, "d": 0.000001, "lam": 5e-07, "L": 1.0, "x": 0.250000, "intensity": 0.000000},
+  {"experiment": "03", "label": "fringe_spacing", "lam": 5e-07, "L": 1.0, "d": 0.000001, "spacing": 0.500000},
+  {"experiment": "03", "label": "eta_zero", "normSq0": 1.0, "normSq1": 0.0, "eta": 0.000000},
+  {"experiment": "03", "label": "eta_half", "normSq0": 0.5, "normSq1": 0.5, "eta": 0.500000},
+  {"experiment": "03", "label": "eta_one", "normSq0": 0.0, "normSq1": 1.0, "eta": 1.000000},
+  {"experiment": "03", "label": "decay_constant_1", "U1": 1.0, "d_sep": 0.000001, "kappa": 0.000001},
+  {"experiment": "03", "label": "decay_constant_2", "U1": 2.0, "d_sep": 0.000001, "kappa": 0.000002},
+  {"experiment": "03", "label": "decay_length_1", "kappa_in": 0.000001, "decay_length": 1000000.000000},
+  {"experiment": "03", "label": "decay_length_2", "kappa_in": 0.000002, "decay_length": 500000.000000}
 ]

--- a/tests/test_differential.py
+++ b/tests/test_differential.py
@@ -112,6 +112,31 @@ def test_doubleslit_matches_oracle(case: dict) -> None:
         )
 
 
+class TestDegenerateCases:
+    """Test degenerate inputs that produce division by zero.
+
+    These cases are physically meaningless (Lean proofs require positive
+    denominators). Python raises ZeroDivisionError; Lean Float would
+    return nan/inf per IEEE 754. The differential test oracle excludes
+    these cases since the Lean proofs require valid inputs.
+    """
+
+    def test_visibility_zero_zero_raises(self) -> None:
+        """visibility(0, 0) → ZeroDivisionError (denominator is zero)."""
+        with pytest.raises(ZeroDivisionError):
+            qphysics.visibility(0.0, 0.0)
+
+    def test_quat_fraction_zero_zero_raises(self) -> None:
+        """quat_fraction(0, 0) → ZeroDivisionError (denominator is zero)."""
+        with pytest.raises(ZeroDivisionError):
+            qphysics.quat_fraction(0.0, 0.0)
+
+    def test_decay_length_zero_raises(self) -> None:
+        """decay_length(0) → ZeroDivisionError (1/0)."""
+        with pytest.raises(ZeroDivisionError):
+            qphysics.decay_length(0.0)
+
+
 class TestBugDetection:
     """Verify the differential testing harness detects intentional bugs.
 


### PR DESCRIPTION
## Summary

Extends the Cedar-pattern differential testing infrastructure to cover Experiment 03 (Double-Slit) scalar functions, completing Phase 4d of Sprint 3.

- **Lean oracle**: Added `floatDecayLength` to `FloatCompute.lean`; updated `Main.lean` to emit input fields alongside outputs for all 17 Exp 03 test cases (37 total oracle predictions)
- **Python functions**: Added 8 DoubleSlit scalar functions to `qphysics.py` mirroring Lean definitions 1:1 (coupling decomposition, visibility, fringe spacing, quaternionic fraction, Fraunhofer intensity, decay constant/length, normSq)
- **Test harness**: Refactored `differential_test.py` with experiment-type dispatch — Exp 03 cases route to `compute_doubleslit_prediction()` which dispatches by label prefix
- **Pytest**: 17 new DoubleSlit parametrized tests + 3 bug detection mutations (coupling sign flip, visibility inversion, decay constant wrong operator)

**Results**: 86 comparisons, 0 divergences. All 83 pytest tests pass.

Closes #301

## Test plan

- [ ] `python3 scripts/differential_test.py --verbose` — 86 comparisons, 0 divergences
- [ ] `python3 -m pytest tests/test_differential.py -v` — 83 tests pass
- [ ] Bug detection: 3 new mutation tests verify harness catches DoubleSlit formula errors
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)