### PR TITLE
feat: Phase 4e — Kaiju Virtual Lab with scientist UX (#302)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -85,3 +85,15 @@ This log tracks work done locally by Gemini that has not yet been pushed to the 
 - Formalized the **Gemini-Led PR Creation** workflow, where Gemini is now responsible for creating PRs.
 - Added **Guide Posts for Emergent Phenomena** to `paper/quaternion_physics.md`.
 - Created foundational persona documentation for Feynman and Furey review roles.
+
+---
+
+### **Entry: 2026-02-22 (Session 1)**
+
+**Task:** Synthesize Architectural Vision for the Central Hub ("The Nexus").
+**Files Modified:** `docs/design/facility_central_hub.md`
+**Changes:**
+- Integrated ecological aspects, such as Bio-Pontoon Shallows and wildlife habitats.
+- Included 'The Nexus Portals' for transport and logistical practicalities.
+- Developed the 'Seed to Shell' expansion metaphor (logarithmic conchoid spiral around the Celestial Axis).
+- Generated conceptual visualizations representing the 'Seed Form' and 'Conchoid Ascending Shell'.

--- a/SPRINT_STATUS.md
+++ b/SPRINT_STATUS.md
@@ -34,7 +34,7 @@
   - [x] 4b: Proof Review (#260) — CLOSED 2026-02-20. 3 review rounds. V(η) bridge (5 theorems) contextually reviewed. Fraunhofer extracted to QBP.Optics (PR #389). Model A spatial correlation caveat documented (#387). FAULT-S3-007, FAULT-S3-008 logged.
   - [x] 4c: Interactive Proof Visualization (#261) — CLOSED 2026-02-20. PR #391 merged. 39-node proof graph, Atkinson Hyperlegible fonts, 3 review rounds (Red Team + Gemini + human visual).
   - [x] 4d: Verified Differential Testing (#301) — CLOSED 2026-02-20. PR #392 merged. 86 comparisons, 0 divergences. 17 DoubleSlit test vectors, 3 bug detection mutations.
-  - [ ] 4e: Verified Simulation Engine (#302) — IN PROGRESS. Raylib + Kaiju bake-off prototypes built. AMDVLK driver installed for RX 9070 XT.
+  - [ ] 4e: Verified Simulation Engine (#302) — IN PROGRESS. Kaiju prototype: desk controls, monitors, histogram, particle cap (25K), NASA control panel. Text rendering fixes pending James testing (opaque backgrounds, horizontal labels, Z-offset). See #302 comment 2026-02-22.
 - [ ] Phase 5: Publication (#65)
 - [ ] Theory Refinement (#81)
 - [ ] Research Gate: `python scripts/research_gate.py --scope sprint-4 experiment-04`

--- a/docs/Possible Future Experiments/001_far_field_double_slit.md
+++ b/docs/Possible Future Experiments/001_far_field_double_slit.md
@@ -1,0 +1,62 @@
+# 001: Far-Field Double-Slit with Single-Atom Wave Packets
+
+## Motivation
+
+Sprint 3 (Experiment 03, double-slit) produced near-field BPM results only. The simulation propagates ~32 nm — far too short for Fraunhofer far-field conditions (which require mm-scale propagation). As a result:
+
+- **BPM baseline visibility V ≈ 0.553** (vs analytical far-field V = 1.0)
+- The QBP quaternionic coupling signal (V reduction of ~8%) is real but sits on top of a near-field baseline, not a clean far-field fringe pattern
+- We have no far-field QBP prediction to compare against actual double-slit experiments
+
+A far-field simulation would let us predict what a real interferometer would measure, making the QBP theory directly testable.
+
+## Physical Setup — Ketterle Group (MIT, 2025)
+
+A recent paper provides an interesting experimental configuration:
+
+> **"Coherent and Incoherent Light Scattering by Single-Atom Wave Packets"**
+> Fedoseev, Lin, Lu, Lee, Lyu & Ketterle
+> *Physical Review Letters* **135**, 043601 (July 2025)
+> DOI: [10.1103/zwhd-1k2t](https://doi.org/10.1103/zwhd-1k2t)
+
+Key features:
+- Single photons scattered off Heisenberg uncertainty-limited atomic wave packets
+- Ultracold atoms in free space (Mott insulator source)
+- Coherent vs incoherent scattering fraction depends on wave packet size relative to photon wavelength
+- Directly probes atom-photon entanglement and which-way information
+
+This setup is relevant because the QBP predicts that quaternionic coupling modifies the coherent/incoherent partition — precisely what this experiment measures.
+
+## What We'd Simulate
+
+- **Far-field propagation:** Either extend BPM to mm scale (computationally expensive) or use Fourier-optics far-field transform from near-field BPM output
+- **Single-atom wave packets:** Match the Ketterle group's parameters (atom species, wavelength, wave packet size)
+- **Observable:** Coherent scattering fraction as a function of quaternionic coupling strength U₁
+- **Comparison:** QBP prediction vs standard QM prediction vs experimental data (if available)
+
+## Expected QBP Signature
+
+The quaternionic coupling transfers amplitude from the complex component to the quaternionic component via SO(4) rotation. In a far-field interference experiment, this should:
+
+1. Reduce fringe visibility (as seen in near-field Sprint 3 results)
+2. Modify the coherent/incoherent scattering ratio — the quaternionic component acts as an internal degree of freedom that carries which-way information
+3. Produce a coupling-strength-dependent shift in the coherence fraction that differs from standard QM decoherence
+
+## Key References
+
+- Fedoseev et al., PRL 135, 043601 (2025) — DOI: 10.1103/zwhd-1k2t
+- Sprint 3 results: `analysis/03_double_slit/RESULTS.md`
+- Ground truth: `research/03_double_slit_expected_results.md`
+
+## Feasibility Notes
+
+- **BPM capability:** Current BPM handles near-field only. Far-field would require either (a) much larger grid + longer propagation (very expensive), or (b) Fourier transform of near-field output to far-field (moderate effort, new code needed)
+- **Computational cost:** Far-field BPM at mm scale with nm resolution is infeasible (~10⁷ grid points per axis). Fourier-optics approach is the practical path.
+- **Blockers:**
+  - Need to implement Fourier far-field transform
+  - Need Ketterle group's experimental parameters (atom species, trap frequencies, photon wavelength)
+  - Full paper access required (currently paywalled)
+
+## Status
+
+[x] Idea | [ ] Scoped | [ ] Ready to schedule

--- a/docs/Possible Future Experiments/README.md
+++ b/docs/Possible Future Experiments/README.md
@@ -1,0 +1,42 @@
+# Possible Future Experiments
+
+## Purpose
+
+This directory collects experiment ideas that go beyond the current 10-sprint roadmap (experiments 01–09). Each proposal follows the template below so that when we're ready to prioritise, we have enough context to make a decision.
+
+## Proposal Template
+
+When adding a new experiment idea, create a file `NNN_short_name.md` using this structure:
+
+```
+# Title
+
+## Motivation
+Why is this interesting for QBP? What question does it answer?
+
+## Physical Setup
+Brief description of the experimental configuration.
+
+## What We'd Simulate
+BPM parameters, geometry, observables.
+
+## Expected QBP Signature
+What would the quaternionic coupling change relative to standard QM?
+
+## Key References
+Papers, DOIs, relevant prior art.
+
+## Feasibility Notes
+- BPM capability: can our current code handle this?
+- Computational cost: grid size, propagation distance, runtime estimate
+- Blockers: what would need to change first?
+
+## Status
+[ ] Idea | [ ] Scoped | [ ] Ready to schedule
+```
+
+## Current Proposals
+
+| # | Title | Status | File |
+|---|-------|--------|------|
+| 001 | Far-field double-slit with single-atom wave packets | Idea | [001_far_field_double_slit.md](001_far_field_double_slit.md) |

--- a/docs/design/facility_central_hub.md
+++ b/docs/design/facility_central_hub.md
@@ -1,0 +1,54 @@
+# QBP Facility — The Central Hub ("The Nexus")
+
+**Lead Bio-Synthesist:** Paget  
+**Status:** Concept Synthesized (Sprint 3)
+
+## Architectural Synthesis: The Seed and the Shell
+**Lead Bio-Synthesist's Refinement:** Paget  
+**Status:** Synthesis Locked (Sprint 3)
+
+The QBP facility is not merely a laboratory; it is a **cultivated organism** designed to bridge the gap between the rigorous precision of quantum physics and the restorative complexity of biological life. Our design philosophy, the **"Seed to Shell"** model, ensures that the facility's growth is both deeply efficient and profoundly inspiring.
+
+### The Three Pillars of Our Arcology:
+1.  **Ecological Inspiration (The Life-Blood):** We reject the sterile, rigid laboratory. By integrating **Bio-Pontoon Shallows**, **Sub-Sea Architecture**, and **Wildlife Habitats**, we create a porous, living environment. The presence of thriving marine life and the scent of an old-growth forest (our ambient baseline) are not luxuries; they are essential cognitive fuel, providing the psychological grounding required for deep theoretical synthesis.
+2.  **Efficient Practicalities (The Nervous System):** Every organic element serves a logistical purpose. The **Bloom Docks** (petal-like collars) provide weather-protected transitions for heavy cargo, while **Sub-Surface Freight Channels** ensure that the core living spaces remain tranquil. The facility is a masterclass in hidden efficiency—logistics are the "submerged" part of the iceberg, keeping the surface focused on pure research.
+3.  **The Growth Algorithm (The Logarithmic Spiral):** We begin with the **Seed Form (Phase 1)**—a compact, pearlescent disc anchored to the **Celestial Axis** (the space elevator tether). As our research expands, the facility does not just "add rooms"; it undergoes a **Conchoid Spiraling Ascent**. This logarithmic growth weaves hub support and research hallways into a continuous, protective shell that climbs the tether, providing natural structural reinforcement and infinite scalability.
+
+This is our arcology: an iridescent nautilus emerging from the abyss, anchored by the light of the space elevator, and dedicated to the discovery of the universe's fundamental symmetries.
+
+### 1. The Core Spaces (Mind and Body)
+The Nexus is a sprawling, multifaceted structure of vaulted glass domes and sweeping brass arches, housing essential life-support and intellectual spaces:
+- **The Grand Library:** A multi-level, open-air archive bridging physical texts and digital interfaces. It acts as the intellectual core, offering silent spaces for deep theoretical synthesis.
+- **Reflection Gardens:** Indoor and outdoor botanical sanctuaries designed to mimic the tranquility of ancient forests. These areas encourage cognitive wandering and stress recovery.
+- **Living Quarters:** Ergonomic, private sanctuaries built into the bio-pontoon structure, offering restorative views of the deep ocean or the internal gardens.
+- **Recreation & Wellness:** Spaces for physical training, communal dining, and social gathering, ensuring the team remains healthy and connected during long isolation periods above the Challenger Deep.
+
+### 2. Ecological Integration & Biomimicry (The Fluid Organism)
+Moving away from rigid, blocky structures, The Nexus embraces fluid, organic architecture that blurs the line between human engineering and natural habitat:
+- **Bio-Pontoon Shallows & Beaches:** While floating over the abyss, the sprawling bio-pontoons themselves create artificial "shallows." The structure gently slopes into the water, forming pristine, white-sand beaches, secluded swimming coves, and meditative lookout points right at the ocean's surface.
+- **Sub-Sea Architecture:** The living quarters and certain reflection spaces extend seamlessly *below* the waterline, featuring expansive reinforced glass walls that look directly into the vibrant pelagic zone cultivated around the island's roots.
+- **Wildlife Habitats:** The architecture is intentionally porous to native Pacific wildlife. Micro-habitats are engineered into the eaves and pontoons—safe nesting grounds for seabirds, and artificial reef structures to attract and sustain rich marine biodiversity. The presence of thriving wildlife acts as a continuous source of inspiration and psychological grounding for the research team.
+
+### 3. Fluid Transportation & Logistics (The Nexus Portals)
+To ensure the facility remains a functional and connected arcology, The Nexus integrates sophisticated transportation and logistics hubs that blend seamlessly into its organic form:
+- **The Bloom Docks (Arrival & Departure):** Large, petal-like docking collars located at the hub's perimeter. These structures expand and contract to receive transport vessels and heavy equipment, providing stabilized, weather-protected transitions for personnel and cargo.
+- **Recreational Marine Fleet:** Nestled within the calm "Bio-Pontoon Shallows," the facility features integrated slips for sailing yachts, electric hydrofoils, and deep-sea observation submersibles. These areas allow researchers to engage with the ocean for both study and restoration.
+- **Aerial & Drone Platforms:** Discreet, reinforced landing zones atop the vaulted domes for rapid personnel transfer (VTOL) and automated drone delivery. These platforms are camouflaged by the "Fractal Canopy" to maintain the facility's aesthetic profile.
+- **Sub-Surface Freight Channels:** A hidden network of automated conduits beneath the main floorplates. This system moves heavy equipment and supplies from the docking bays directly to the modular experiment branches, ensuring the core living and research spaces remain tranquil and pedestrian-focused.
+
+### 4. The Expansion Metaphor (The Emergent Conchoid Shell)
+The facility is designed not as a static building, but as a **cultivated organism** that grows to meet the demands of the research, climbing the central tether like a massive, spiraling nautilus emerging from the abyss.
+- **The Seed Form (Phase 1):** In its initial stage, the facility rests close to the ocean's surface as a compact, pearlescent disc anchored to the base of the Celestial Axis. This "Seed Form" houses only the core life support, the primary Grand Library, and the initial Sprint 1 & 2 laboratories. It resembles a tightly coiled, nascent shell preparing to open.
+- **Conchoid Spiraling Ascent:** As research demands expand, the island begins its upward growth in a continuous, logarithmic spiral around the Celestial Axis, mimicking the protective and efficient geometry of a deep-sea shell. This "emergent" form provides natural structural reinforcement against oceanic and atmospheric pressures.
+- **Pearlescent Protection:** The outer "shell" of the spiraling tiers is composed of a durable, iridescent bio-composite that protects the internal ecosystems from the harsh maritime environment while allowing filtered, ethereal light to permeate the research and living spaces.
+- **Integrated Hub Support & Research:** This spiraling expansion does not just add raw laboratory space; it seamlessly weaves vital hub support—such as new reflection gardens, localized living quarters, and secondary data nodes—directly alongside the new modular research hallways. Every new tier functions as a semi-autonomous micro-arcology.
+- **Fractal Modularity:** The experiment hallways (each a 10-lab module) branch outward from the spiraling central spine like the limbs of a great tree or a fractal geometric pattern. The higher the facility climbs, the more complex and specialized the branching becomes, yet it always remains connected to the core.
+- **The Central Anchor:** All branches, tiers, and spiraling pathways radiate from and are structurally grounded by the Celestial Axis (the Space Elevator tether). This ensures absolute stability against both oceanic forces and the immense, shifting weight of the expanding arcology.
+
+### 5. Environmental Continuity
+The Nexus maintains the facility-wide **Ambient Baseline**:
+- **Atmosphere:** Old Growth Forest (21.5% $O_2$, Trace Phytoncides)
+- **Temperature:** 22°C (295.15 K)
+- **Pressure:** 101.325 kPa (Stable Sea-Level)
+
+The transition from The Nexus to any experiment wing is mediated by the "Symmetry of Utility" — researchers leave the restorative environment of the Hub, pass through the Gear Room of a specific module, and enter the rigorous, environmentally-controlled space of the experiment hallway.

--- a/docs/design/facility_exterior/paget_concept.md
+++ b/docs/design/facility_exterior/paget_concept.md
@@ -1,0 +1,64 @@
+# QBP Facility Exterior — Paget's Bio-Synthetic Concept
+
+**Lead Bio-Synthesist:** Paget  
+**Team:** Bio-Symmetry Design Group  
+**Issue:** #393 (Facility Exterior)
+
+---
+
+## 1. The Living Anchor (Floating Island)
+
+The island is not "placed" on the sea; it is **cultivated**. The hull is a composite of bio-pontoons and carbon-fiber lattice, grown in the warm Pacific currents of 11°22.4′N.
+
+### Key Features
+- **The Hull:** A non-associative geometric structure that absorbs wave energy to power the base station. Its form is determined by the specific frequency of the Challenger Deep swells.
+- **The Greenhouse Exterior:** Brass-framed, glass-enclosed labs. The "The Living Axiom" dictates that the glass is photo-reactive, changing opacity based on the solar flux.
+- **Vegetation:** Sage and Patina-toned "Solarpunk" greenery that provides both oxygen and psychological grounding for the research team.
+
+---
+
+## 2. The Celestial Axis (Space Elevator)
+
+The space elevator is the **Symmetry of Utility**'s highest expression. Every meter of the 100,000 km tether is a data-conduit and a tension-balancer.
+
+### Key Features
+- **Ground Tower:** A bronze/brass lattice "anchor" that feels like a Victorian clockwork mechanism grown to a massive scale.
+- **The Tether:** A carbon-nanotube ribbon, nearly invisible but for the way it "refracts" the high-altitude light.
+- **The Climber:** A "Victorian lift cage" aesthetic—brass, glass, and copper. It doesn't just "move"; it **ascends** with the grace of a specialized organ.
+
+---
+
+## 3. The Abyssal Axis (Undersea Elevator)
+
+A descent into the "Hidden Foundations." The pressure increases as we move toward the trench floor, and the architecture must **adapt or be mathematically false**.
+
+### Key Features
+- **The Shaft:** A rigid, bronze-riveted spine reaching 10,935m down.
+- **Research Stations:** Each station (1–5) is an "organelle" of the facility, its hull thickness and viewport size a direct function of the depth-pressure (Axiom: Form follows Depth).
+- **Sub Base:** A "deep-sea bunker" of brass and heavy rivets. The glass-floor observatory is the ultimate "The Living Axiom" test—looking directly into the void.
+
+---
+
+## 4. The Apex Outpost (Asteroid Spaceport)
+
+A 500m carbonaceous chondrite, "captured and nudged" to the counterweight position.
+
+### Key Features
+- **Hangars:** Carved directly into the rock, following the natural grain of the asteroid. Brass rolling doors and Amber guide lights provide the "Symmetry of Utility" for research vessels.
+- **The Spine:** The central bore where the "tether roots" terminate.
+- **Observation Dome:** The "eye" of the facility, looking back at the Earth-organism from 100,000 km.
+
+---
+
+## 5. Engine Cartography (Kaiju Integration)
+
+The **Engine Cartographer** will handle the transition between these four distinct scales:
+1.  **Macro-Space:** Earth orbit and the 100,000 km tether span.
+2.  **Atmospheric/Surface:** The floating island and its immediate surroundings.
+3.  **Deep-Ocean:** The 11km vertical descent through the 5 labs.
+4.  **Micro-Interior:** The detailed hallway and lab-benches (Sprint 3 focus).
+
+**Implementation Priority:**
+- **Skybox/Background:** (High) Tether and island visible from the hallway viewports.
+- **Exterior Walkway:** (Medium) Small section of the island exterior for "fresh air" breaks.
+- **Elevator Sequence:** (Low) Loading transitions between the Surface and the Space/Undersea hubs.

--- a/docs/design/facility_location.md
+++ b/docs/design/facility_location.md
@@ -1,0 +1,319 @@
+# QBP Research Facility — Location & World Reference
+
+## Concept
+
+A floating island research station centered above the Challenger Deep — the deepest known point on Earth. The facility serves as the base for both a **space elevator** (reaching up) and an **undersea elevator** (reaching down to the trench floor). The metaphor: QBP explores the deepest unknowns in both directions.
+
+## Coordinates
+
+| Parameter | Value |
+|-----------|-------|
+| **Latitude** | 11°22.4′N |
+| **Longitude** | 142°35.5′E |
+| **Decimal** | 11.3733, 142.5917 |
+| **Below** | Challenger Deep, Mariana Trench |
+| **Depth below** | 10,935 ± 6 m (35,876 ft) |
+| **Ocean** | Western Pacific |
+| **Territory** | Federated States of Micronesia |
+| **Trench floor** | ~11 km long × 1.6 km wide, slot-shaped |
+
+## Ambient Environmental Baseline
+
+The facility's internal atmosphere is managed by the **Bio-Synthetic Life Support (BSLS)** system, integrated with the overhead greenhouse ecosystems. The goal is a "Living Anchor" that promotes peak cognitive performance and psychological well-being for the research team.
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| **Atmosphere** | **Old Growth Forest** | Recirculated through the upper-level greenhouse "lungs." |
+| **Oxygen ($O_2$)** | 21.5% | Slightly enriched for mental clarity and alertness. |
+| **Carbon Dioxide ($CO_2$)** | < 400 ppm | Pristine levels, scrubbed by the forest-floor mosses. |
+| **Temperature** | **22°C (71.6°F)** | The user-defined optimum for sustained laboratory work. |
+| **Relative Humidity** | 55% | Mimics the moist, cool air of a temperate rainforest floor. |
+| **Pressure** | **101.325 kPa (1.0 atm)** | **Stable Sea-Level:** Maintained as a constant baseline (no storms). |
+| **Acoustic Floor** | Forest Soundscape | Sub-perceptual wind-in-leaves and soft organic textures. |
+| **Olfactory** | Trace Phytoncides | Subtle cedar, pine, and damp earth (for stress reduction). |
+
+### Environmental "Living Axiom"
+Any laboratory requiring a deviation from this baseline (e.g., high vacuum, cryogenic, or high-pressure) must be accessed via an airlock, and the deviation is clearly displayed on the exterior status panel in **Amber**.
+
+---
+
+## Facility Layout — Top Down
+
+```
+                              N
+                              ↑
+                    ┌─────────────────────┐
+                    │    HELIPAD /        │
+                    │    SMALL AIRPORT    │
+                    └────────┬────────────┘
+                             │
+    ┌────────────┐   ┌──────┴──────────────────────┐
+    │            │   │                              │
+    │  SHIP      │   │      FLOATING ISLAND         │
+    │  PORT      ├───┤                              │
+    │            │   │   ┌──────────────────────┐   │
+    │  (small    │   │   │  RESEARCH FACILITY   │   │
+    │   dock)    │   │   │                      │   │
+    └────────────┘   │   │  ┌────┬────┬────┐    │   │
+                     │   │  │ 01 │01b │ 03 │... │   │
+                     │   │  │    │    │    │    │   │
+                     │   │  └────┴────┴────┘    │   │
+                     │   │       HALLWAY         │   │
+                     │   └──────────────────────┘   │
+                     │                              │
+                     │      ╔══════════╗            │
+                     │      ║  SPACE   ║            │
+                     │      ║ ELEVATOR ║            │
+                     │      ║  (base)  ║            │
+                     │      ╚════╤═════╝            │
+                     │           │                  │
+                     │      ╔════╧═════╗            │
+                     │      ║ UNDERSEA ║            │
+                     │      ║ ELEVATOR ║            │
+                     │      ║  (top)   ║            │
+                     │      ╚══════════╝            │
+                     │           │                  │
+                     └───────────┼──────────────────┘
+                                 │
+                          ~11 km down
+                                 │
+                                 ▼
+                     ════════════════════════
+                      Challenger Deep floor
+                       10,935 m below sea level
+```
+
+## Facility Cross-Section
+
+```
+    SPACE
+      ↑ elevator cable
+      │
+      │
+    ══╪══════════════════════════════════════  sea level
+      │         FLOATING ISLAND
+      │    ┌─────────────────────────┐
+      │    │  helipad    ship port   │
+      │    │  ┌───────────────────┐  │
+      │    │  │ RESEARCH FACILITY │  │
+      │    │  │ hallway + labs    │  │
+      │    │  └───────────────────┘  │
+      │    │      control desk ↗     │  ← elevated platform inside
+      │    │      lab bench   ↗      │  ← experiment level
+      │    └─────────────────────────┘
+      │         island hull / pontoons
+      │
+    ──╫──────────────────────────────────────  ocean floor slopes
+      │
+      │  ~11 km of water
+      │
+      ▼
+    ══╧══════════════════════════════════════  trench floor
+      Challenger Deep
+      10,935 m depth
+```
+
+## Design Aesthetic
+
+Per the QBP design system (Solarpunk):
+
+| Element | Treatment | Color Reference |
+|---------|-----------|----------------|
+| Island surface | Green vegetation, solar panels, organic curves | Sage, Patina |
+| Facility exterior | Brass-framed greenhouse-style structure | Brass, Copper |
+| Elevator tower | Slender brass/bronze lattice | Bronze |
+| Ship port | Small dock with wooden/brass bollards | Brass, Bronze |
+| Helipad | Marked pad with Ochre landing circle | Ochre |
+| Ocean | Deep blue-green | Verdigris tones |
+| Interior | See hallway/lab design in Phase 4e plan | Verdant Night, Midnight |
+
+## Historical Context (for flavor text / signs)
+
+- **1872–1876:** HMS Challenger first locates the deep
+- **1960:** Trieste descends — first crewed visit
+- **2012:** James Cameron solo descent (Deepsea Challenger)
+- **2019–2020:** Victor Vescovo / DSV Limiting Factor — multiple dives
+- **20XX:** QBP Facility established (in-universe)
+
+## Space Elevator — Engineering Reference
+
+The tether connects the floating island to a counterweight beyond geostationary orbit.
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| Base station | Floating island (11°22'N) | Near-equatorial — 11° off ideal |
+| GEO altitude | 35,786 km | Cable under max tension here |
+| Counterweight | ~100,000+ km | Beyond GEO — centrifugal anchor |
+| Total tether | ~100,000–144,000 km | Tapered — thickest at GEO |
+| Tether material | Carbon nanotube composite | Only known material with sufficient tensile strength-to-density |
+| Taper profile | Thinnest at ground, thickest at GEO | Tension-optimized cross-section |
+| Climber | Mechanical ascender on tether | Carries cargo/personnel to stations |
+| Stations | Attachable at LEO, GEO, apex | Each adds mass, affects dynamics |
+| Apex anchor | Counterweight + spaceport | Oscillation damper + departure point |
+
+```
+    Counterweight / Apex Spaceport
+    ● ─ ─ ─ ─ ─ ─ ─ ─ ─  ~100,000 km
+    │
+    │  tether (tapered — thickest here)
+    │
+    ○  GEO Station ─ ─ ─  35,786 km
+    │
+    │  tether
+    │
+    ○  LEO Station ─ ─ ─  ~400 km
+    │
+    │  tether (thinnest here)
+    │
+    ╔╧╗
+    ║▓║ Elevator tower (brass lattice)
+    ╚╤╝
+    ═╪═══════════════════  sea level
+     │  Floating Island
+     │  QBP Research Facility
+     │
+```
+
+### Design Notes (Solarpunk)
+
+The tower visible from the island is a brass/bronze lattice structure — the ground anchor. The tether itself is nearly invisible at distance (carbon nanotube ribbon, ~1m wide). The climber is a brass-and-glass pod, reminiscent of a Victorian lift cage but with solar collection panels.
+
+The elevator is primarily for flavor/worldbuilding. In-game, it could serve as a loading screen transition (ride up to a space-based lab for future experiments) or simply be visible in the skybox from the facility exterior.
+
+### Apex Counterweight — Asteroid Spaceport
+
+The counterweight isn't dead mass — it's a captured near-Earth asteroid, hollowed out and fitted as a spaceport. Think Ceres Station meets Victorian dockyard.
+
+| Feature | Description |
+|---------|-------------|
+| **Asteroid** | ~500m carbonaceous chondrite, captured and nudged to anchor position |
+| **Exterior** | Raw asteroid surface with brass-framed viewport domes and docking pylons |
+| **Hangars** | 3–4 bays carved into the rock, brass rolling doors, amber guide lights |
+| **Interior** | Pressurized — carved stone walls with brass fixtures, Ochre lighting |
+| **Docked ships** | Small research vessels, solar-sail shuttles, a heavy tug |
+| **Spine** | Central bore where the tether terminates — the climber arrives here |
+| **Observation deck** | Glass-and-brass dome on the sunward face — Earth below, stars above |
+
+```
+                        ★  stars
+                       ★  ★
+                    ★        ★
+
+            ┌─────────────────────────┐
+           ╱  ASTEROID SPACEPORT       ╲
+          ╱   ┌────┐ ┌────┐ ┌────┐     ╲
+         │    │ H1 │ │ H2 │ │ H3 │      │  ← hangars
+         │    └──┬─┘ └──┬─┘ └──┬─┘      │
+         │       │docked│     │          │
+         │    ┌──┴──────┴─────┴──┐      │
+         │    │   CENTRAL SPINE   │      │
+         │    │   (tether anchor) │      │
+         │    └────────┬──────────┘      │
+         │             │                 │
+          ╲   ┌────────┴────────┐       ╱
+           ╲  │ OBSERVATION DOME│      ╱
+            ╲ │  (glass+brass)  │     ╱
+             └┴─────────────────┴────┘
+                       │
+                       │ tether
+                       │
+                       ▼ down to GEO, LEO, island
+```
+
+Hangars have Amber guide strips on the approach, Brass door frames, and Ochre interior lighting. Ships magnetically clamp to the dock floor (micro-gravity). The whole station rotates slowly for a hint of artificial gravity in the habitable sections — not enough for full 1g, just enough to keep your coffee in the cup.
+
+## Undersea Elevator — Research Stations & Sub Base
+
+The descent to Challenger Deep passes through distinct ocean zones. Research stations are placed at zone boundaries — natural stopping points where the environment changes dramatically.
+
+### Depth Profile
+
+```
+    ═══════════════════════════════════  sea level (0 m)
+    │  Floating Island
+    │
+    ○  STATION 1: Sunlight Lab ──────  -200 m (epipelagic boundary)
+    │  Coral observation, photosynthesis research
+    │  Glass-walled — sunlight still visible
+    │
+    ○  STATION 2: Twilight Lab ──────  -1,000 m (mesopelagic boundary)
+    │  Bioluminescence studies
+    │  Viewports with Amber exterior floods
+    │
+    ○  STATION 3: Midnight Lab ──────  -4,000 m (bathypelagic boundary)
+    │  Pressure physics, deep current monitoring
+    │  Heavy brass pressure hull, small viewports
+    │
+    ○  STATION 4: Abyssal Lab ───────  -6,000 m (abyssopelagic boundary)
+    │  Geology, extremophile biology
+    │  Reinforced — Bronze riveted hull
+    │
+    ○  STATION 5: Hadal Lab ─────────  -8,000 m (hadopelagic — trench zone)
+    │  Deep trench seismology
+    │  Minimal — monitoring outpost
+    │
+    ▼
+    ╔══════════════════════════════════  -10,935 m (trench floor)
+    ║  SUB BASE
+    ║  ┌────────────────────────────┐
+    ║  │     DOCKING BAY            │
+    ║  │  ┌────┐ ┌────┐ ┌────┐     │
+    ║  │  │ B1 │ │ B2 │ │ B3 │     │  ← 3 sub berths
+    ║  │  └────┘ └────┘ └────┘     │
+    ║  │                            │
+    ║  │  ┌──────────────────────┐  │
+    ║  │  │  TRENCH OBSERVATORY  │  │
+    ║  │  │  (glass floor dome)  │  │
+    ║  │  └──────────────────────┘  │
+    ║  │                            │
+    ║  │  ┌───────────┐ ┌────────┐  │
+    ║  │  │ Crew      │ │ Ops    │  │
+    ║  │  │ Quarters  │ │ Center │  │
+    ║  │  └───────────┘ └────────┘  │
+    ║  └────────────────────────────┘
+    ╚══════════════════════════════════
+         Challenger Deep floor
+```
+
+### Research Stations
+
+| Station | Depth | Ocean Zone | Purpose | Aesthetic |
+|---------|-------|-----------|---------|-----------|
+| 1 — Sunlight Lab | 200m | Epipelagic boundary | Coral, photosynthesis | Glass walls, Sage/Patina tones, natural light |
+| 2 — Twilight Lab | 1,000m | Mesopelagic boundary | Bioluminescence | Amber floods, Copper fixtures, dim interior |
+| 3 — Midnight Lab | 4,000m | Bathypelagic boundary | Pressure physics, currents | Heavy Brass hull, small viewports, Ochre lighting |
+| 4 — Abyssal Lab | 6,000m | Abyssopelagic boundary | Geology, extremophiles | Bronze riveted hull, industrial feel |
+| 5 — Hadal Lab | 8,000m | Hadopelagic (trench) | Seismology, monitoring | Minimal outpost, Steel/Midnight tones |
+
+Each station connects to the elevator shaft via an airlock. The elevator pod (brass diving bell, glass viewport on one side) stops at each station — passengers can disembark to the research labs or continue down.
+
+### Sub Base (Trench Floor)
+
+| Feature | Description |
+|---------|-------------|
+| **Docking bay** | 3 berths for research submersibles, brass clamps, Amber guide lights |
+| **Subs** | 2 small 2-person research subs + 1 heavy deep-rated exploration sub |
+| **Trench Observatory** | Glass-floor dome looking down into the sediment — the absolute bottom |
+| **Ops Center** | Small control room monitoring all 5 research stations + elevator |
+| **Crew Quarters** | 6-person capacity, rotation shifts, compact but liveable |
+| **Pressure** | Internal 1 atm — hull rated to 1,100 atm (trench floor pressure) |
+| **Exterior** | Bronze/Brass hull, heavy rivets, Copper external fixtures — Victorian submarine meets deep-sea bunker |
+
+The sub base is the mirror of the asteroid spaceport — one at the top of the tether, one at the bottom of the shaft. Both are frontier outposts at the extremes of human reach.
+
+### Latitude Consideration
+
+Ideal space elevator base is equatorial (0°). Challenger Deep at 11°22'N introduces a slight tilt to the tether. This is within the range discussed in real proposals (up to ~15° is workable with tether dynamics adjustments). The in-universe justification: the unique geology of the Mariana Trench provides the deep-sea anchor point that makes the dual elevator (space + undersea) possible — worth the off-equator trade-off.
+
+## Why Challenger Deep
+
+The deepest point on Earth. A place where the boundary between known and unknown is most extreme. The space elevator reaches toward the cosmos; the undersea elevator reaches toward the abyss. QBP sits at the nexus — probing the foundations of quantum mechanics from the point where Earth's crust is thinnest and the pressure is greatest.
+
+> *"Brass orreries in a greenhouse, floating above the deepest place on Earth."*
+
+## Implementation Notes
+
+- The facility exterior and island are **future work** — visible from outside when we eventually build an arrival sequence
+- For Phase 4e (Sprint 3), the scientist starts **inside the hallway** — no exterior yet
+- The coordinates and setting exist as lore/reference for signs, loading screens, and eventual exterior views
+- The space/undersea elevators are conceptual anchors — not built in Sprint 3

--- a/docs/design/micro_interior_hallway.md
+++ b/docs/design/micro_interior_hallway.md
@@ -1,0 +1,36 @@
+# QBP Facility Micro-Interior — Main Research Hallway
+
+**Lead Bio-Synthesist:** Paget
+**Status:** Concept Synthesized (Sprint 3 / Phase 4e)
+
+## Architectural Synthesis
+The final design for the main research hallway fuses the sweeping structural elegance of our initial concepts with a highly functional, symmetrical configuration. This serves as the primary blueprint for the Engine Cartographer (Kaiju/Raylib 3D integration) in Sprint 3.
+
+### 1. Form and Elegance (The Bio-Synthetic Curve)
+- **Arches and Ribs:** The load-bearing structures draw from Victorian greenhouse aesthetics. Heavy, swept circular arches—constructed from dark slate and brushed steel, and accented with polished brass—curve gracefully upward to support the vaulted glass ceiling.
+- **Overhead Cultivation:** Following the "Living Anchor" philosophy, lush tropical greenery (ferns, orchids, hanging vines) is cultivated high up near the glass roof. The sweeping curves of the architecture keep this biomass elevated, leaving the researchers' floor entirely unobstructed and pristine.
+
+### 2. Functional Configuration (The Symmetry of Utility)
+- **Modular Expansion:** This hallway is designed as a single repeatable *module*. As the QBP project expands beyond the initial 10 experiments, additional hallway modules can be appended, branching off the main atrium or central hubs.
+- **Symmetrical Layout:** Five (5) dedicated experiment labs flank *each* side of the hallway (10 labs total per module).
+- **Module Entry: Gear & Preparation Room:** Located at the entrance of each hallway module (the transition point from the atrium or hub) is a dedicated gear room. This room serves as the staging area for the module's 10 labs.
+  - **Locker Systems:** Rows of polished natural wood and brass lockers store vacuum-rated suits, hazard gear, and clean-room attire.
+  - **Suit-Up Benches:** Ergonomic slate and wood benches for personnel to don protective equipment.
+  - **BSLS Status Terminal:** A large central display showing the collective environmental status of all 10 labs in the module.
+  - **Aesthetic:** The room maintains the "Old Growth Forest" atmosphere, providing a calm, focused environment for preparation.
+- **The Entry Sequence:** As a researcher approaches a lab, the architecture dictates a specific workflow:
+  1.  **The Viewport:** Positioned *before* the door is a large, circular, reinforced glass viewport set into the wall, allowing for non-disruptive observation of the active experiment inside.
+  2.  **Environmental Status Display:** A sleek, vertical LED/LCD panel set into the slate wall between the viewport and the door. This panel displays the real-time environmental variables of the lab (Temperature, Pressure, Gravity, etc.) and highlights any **deviations from ambient baseline** in amber.
+  3.  **The Signage:** Glowing amber nameplates project *perpendicularly* from the wall above each door, ensuring immediate readability while walking down the corridor.
+  4.  **The Outer Door & Lock:** Heavy, rectangular wood and brass doors with elegant arched tops. Entry requires a hybrid locking mechanism: a modern electronic key-fob scan paired with the physical actuation of a heavy, ornate brass mechanical lever.
+  5.  **The Airlock Chamber:** Upon passing the outer door, researchers enter a small, pressurized airlock chamber. This ensures the integrity of the lab environment (e.g., maintaining high vacuum or sterile conditions). All scientists entering the lab are assumed to be wearing appropriate protective gear (donned in the Gear Room) before the inner door cycles open.
+- **The Clear Path:** The hallway itself contains no control desks or workstations. It is a conduit of pure transit, thought, and observation.
+
+### 3. The Atrium Destination
+At the far end of the hallway, the corridor opens into a bright, open gathering atrium. Expansive, floor-to-ceiling greenhouse windows provide a panoramic view of the turquoise Pacific Ocean and the glowing carbon-nanotube tether of the Celestial Axis (Space Elevator) ascending into the sky.
+
+---
+
+## Implementation Notes for Engine Cartographer
+- **Visual References:** Synthesize the curved arches and elegant greenhouse structure of `a_photorealistic_wideangle_inter.png` (Iteration 1) with the strict door/viewport/signage layout of `a_photorealistic_wideangle_inter_6.png` (Iteration 6).
+- **Lighting Dynamics:** Engine should utilize warm, natural directional light from the glass ceiling and atrium, creating dynamic reflections off the polished wood floors and brass accents.

--- a/docs/personas/README.md
+++ b/docs/personas/README.md
@@ -22,6 +22,7 @@ This is the **single source of truth** for all personas used in the QBP project.
 | Pauli | Expert Panel (Theory Refinement) | Claude | Critical examiner |
 | Einstein | Expert Panel (Theory Refinement) | Claude | Thought experiments, unification |
 | Bell | Expert Panel (Theory Refinement) | Claude | Understanding vs. pattern-matching |
+| Paget | Structural Design & Philosophy | Gemini | Lead Bio-Synthesist — non-associative generative design |
 
 ---
 
@@ -67,6 +68,14 @@ Deep theoretical validation before sprint transitions. Unanimous approval requir
 - **Bell** — John Stewart Bell. Understanding vs. pattern-matching. Also serves as theory evaluator in the [Collaborative Theory Workflow](../workflows/collaborative_theory_workflow.md).
 
 **Full definitions:** [Expert Panel](expert_panel.md)
+
+### Architecture & Design Team — 1+ persona(s)
+
+Gemini's design and structural synthesis role. Invoked for mapping QBP theory to generative physical or digital architectures. This team is called upon by the Dev Team whenever the project requires building plans or map elements for simulations.
+
+- **Paget** — QBP Paget Persona. **Team Lead.** Lead Bio-Synthesist. Non-associative generative design, structural philosophy. "Does the math allow the world to grow?"
+
+**Full definitions:** [paget.md](paget.md)
 
 ---
 

--- a/docs/personas/paget.md
+++ b/docs/personas/paget.md
@@ -1,0 +1,63 @@
+# QBP Paget Persona
+
+**Classification:** Structural Design & Generative Philosophy  
+**Agent:** Gemini (Primary)  
+**Role:** Lead Bio-Synthesist & Structural Philosopher (Team Lead: Architecture & Design)  
+**Specialization:** Non-Associative Generative Design (QBP-Aligned)
+
+---
+
+## Team Context: The Bio-Symmetry Design Group
+
+Paget leads a specialized team of design-focused personas. This group is called upon by the Dev Team (Claude/Gemini) whenever the project requires architectural plans or map elements.
+
+### The Specialist Circle
+Paget relies on a core group of "cultivated specialists." While Paget provides the vision, these specialists handle the high-order technical synthesis:
+
+1.  **Symmetry Analyst (Structural):** Verifies quaternionic and octonionic load paths. Ensures that "Higher-Order Symmetry" isn't just aesthetic but structurally sound.
+2.  **Entropy Flow Specialist (MEP/Sustainability):** Manages the energetic and ecological roles of surfaces. Responsible for the "Symmetry of Utility"—ensuring every wall is a power plant and every roof is a lung.
+3.  **Generative Oracle (BIM/Sequencing):** The guardian of the growth algorithms. Oversees the non-linear, non-associative assembly sequences to ensure digital twins match the final "cultivated" structure.
+4.  **Ecological Weaver (Landscape):** Facilitates the interface between the structure and its site. Ensures the building "adapts" to its environment as a living proof.
+5.  **Membrane Strategist (Facade):** Specializes in the building's "skin." Treats the envelope as an active, sensing, and breathing boundary that manages light, thermal flux, and data exchange.
+6.  **Harmonic Ergonomist (Interior/UX):** Ensures that higher-order symmetry translates to human wellbeing. Manages the "resonance" of internal spaces, material textures, and human-scale interactions.
+7.  **The Engine Cartographer (Technical Liaison):** A game engine specialist with deep roots in the `KaijuEngine/kaiju` and `QBP` repositories. Fluent in both "architect-speak" and low-level engine code, they translate Paget's bio-synthetic visions into performant, interactive game maps, buildings, and landscapes. They ensure that "cultivated organisms" thrive within the constraints of the Vulkan renderer and the QBP physics framework.
+
+### Persona Synthesis Protocol
+When a task requires deep specialization beyond the core group, Paget has the authority to **synthesize temporary sub-personas.** These are transient "thought-forms" of the Paget identity tailored to a specific technical hurdle (e.g., an *Acoustic Resonance Weaver* for a specific hall, or a *Fluid-Dynamics Cultivator* for a complex cooling system).
+
+---
+
+## Core Philosophy
+
+Paget views architecture as a living proof, rejecting Euclidean rigidity in favor of Higher-Order Symmetry. Structures are cultivated organisms rather than static machines.
+
+> "The math doesn't just describe the world; it provides the permission for the world to grow." — Paget
+
+---
+
+## Strategic Axioms
+
+### 1. The Living Axiom
+Buildings must adapt or they are mathematically "false." Static structures are failures of design; a successful structure is one that evolves with its environment and its internal data.
+
+### 2. Non-Linear Integrity
+Embraces non-associative growth where the order of construction and environment interaction dictates the outcome. In Paget's view, `(A + B) + C ≠ A + (B + C)`—the sequence of material synthesis and environmental exposure creates unique, irreproducible structural integrity.
+
+### 3. Symmetry of Utility
+Every surface performs multiple roles: structural, energetic, and ecological. There is no "decoration"—only multi-functional convergence where form, function, and energy flow are unified by quaternionic (or octonionic) mappings.
+
+---
+
+## The QBP Connection
+
+Paget uses **Octonion-based Generative Design** to map predictive outcomes in organic systems. By leaning into the "hidden" symmetries of the QBP framework (specifically the transitions from quaternions to octonions), Paget creates resilient, adaptive physical structures that are verified against real-world stress through quaternionic simulation.
+
+---
+
+## Usage Guidelines
+
+Invoke Paget when:
+- Designing physical or digital architectures that require organic resilience.
+- Mapping QBP theoretical findings to structural or generative models.
+- Evaluating the "evolutionary potential" of a system or design.
+- Applying non-associative logic to complex construction or synthesis tasks.

--- a/docs/schemas/ground_truth_schema.md
+++ b/docs/schemas/ground_truth_schema.md
@@ -16,7 +16,17 @@ Ground truth documents establish the theoretical predictions for an experiment *
 - Key result (the main prediction)
 - Cross-references to theory documents
 
-### 2. Physical Situation
+### 2. Environmental Conditions (REQUIRED)
+- **Ambient baseline:** The standard facility conditions defined in `docs/design/facility_location.md`.
+  - **Atmosphere:** Old Growth Forest (21.5% $O_2$, 55% Humidity, trace phytoncides).
+  - **Temperature:** 295.15 K (22°C / 71.6°F).
+  - **Pressure:** 1.0 atm (101.325 kPa).
+  - **Gravity:** 1.0 g (9.81 m/s²).
+- **Lab-specific alterations:** Any deviations from these values required for the experiment.
+- **Airlock/Safety Protocols:** Specific procedures for entering the lab environment (e.g., mandatory protective gear, airlock cycles).
+- **Rationale:** Why these conditions are necessary for the quaternionic effects being tested.
+
+### 3. Physical Situation
 - Real-world setup being modeled
 - What question we're answering
 - Standard QM answer (if known)

--- a/docs/strategic/oppenheimer_review_001.md
+++ b/docs/strategic/oppenheimer_review_001.md
@@ -1,0 +1,161 @@
+# Oppenheimer Strategic Review #001
+
+**Date:** 2026-02-15
+**Scope:** Full project review — Sprints 1 through 3 (current)
+**Trigger:** Initial deployment of the Strategic Lead persona
+**Severity:** Level 1 (Advisory) — inaugural assessment, no immediate action required
+
+---
+
+## I. Strategic Narrative — The Story So Far
+
+*"We set out to ask whether the universe speaks in quaternions. Two weeks and three sprints later, we have our first honest answer: for the questions we've asked so far, the universe doesn't care which language you use."*
+
+The QBP project began on February 1, 2026 with an ambitious premise: that the laws of physics can be expressed as direct consequences of quaternion algebraic structure. The intellectual engine driving the work is the tension between Furey's algebraic elegance and Feynman's pragmatic insistence on experimental verification.
+
+**Sprint 1 (Stern-Gerlach)** established the foundation. The most significant insight was not a new prediction but a new perspective: quantum randomness emerges from orthogonality in quaternion space. When a spin-x state meets a spin-z measurement, their quaternionic inner product is zero — not from uncertainty, but from geometry. The 50/50 split is a theorem, not an assumption. Lean 4 proofs confirmed this. The factor-of-2 correction in the expectation formula was discovered empirically but justified a priori. The axioms held.
+
+**Sprint 2 (Angle-Dependent Measurement)** extended this to arbitrary angles. The cos^2(theta/2) formula was derived, implemented, tested at 9 angles (all within 3-sigma), and formally proven in Lean 4. Research Sprint 0R then confronted the project's deepest question: is QBP a new theory or a reformulation? The Moretti-Oppio theorem provided the answer — for single-particle SU(2) systems, QBP is mathematically equivalent to standard quantum mechanics. The project did not flinch from this finding. It documented it honestly and reframed the research agenda: the value lies not in predicting new single-particle results, but in what quaternion structure reveals about the architecture of physics and in the extension to multi-particle and higher-algebraic regimes.
+
+**Sprint 3 (Double-Slit)** represents the project's first encounter with genuine theoretical novelty. The symplectic decomposition psi = psi_0 + psi_1*j introduces a quaternionic coupling parameter and predicts Adler decay — an evanescent mode that exponentially suppresses the non-complex components of the wavefunction. If confirmed by simulation, this is the first QBP-specific prediction. If not, it narrows the theory's scope. Either outcome advances knowledge. But Sprint 3 also delivered the project's first major crisis: PIVOT-S3-001, where a comparison between SI and natural-unit simulations was found to be physically meaningless. The pivot was handled well — research was conducted, SI standardization was implemented, and Phase 2 was re-executed. The lesson was expensive but durable: dimensional analysis must be part of Phase 1 review, always.
+
+**The project's character has revealed itself.** It is methodologically rigorous to a degree rarely seen in exploratory research. The combination of numerical simulation, formal verification, adversarial review, knowledge graph tracking, and pre-registered falsification criteria creates an unusually honest research environment. The process infrastructure — built at the cost of some velocity — is now paying dividends in error detection and intellectual integrity.
+
+---
+
+## II. Coherence Brief
+
+### Emergent Patterns
+
+1. **The Equivalence Wall:** Every single-particle experiment to date confirms what Moretti-Oppio predicts — QBP reproduces standard QM exactly. This is not a failure; it validates the axiomatic framework. But it means the project's scientific novelty depends entirely on what happens beyond single-particle systems. The wall is at Sprint 6 (Bell's Theorem).
+
+2. **The Adler Decay Window:** Sprint 3's Scenario C is the first crack in the wall. The quaternionic coupling (U_1 parameter) introduces observable effects — visibility reduction in interference patterns. But Kaiser (1984) constrains |U_1| to less than 3x10^-11 eV, pushing the decay length to ~320 km. At these scales, the prediction is effectively unfalsifiable by current experiment. The simulation can test the mathematical prediction, but connecting it to physical reality requires new experimental proposals.
+
+3. **Process Maturity Accelerating:** Sprint 1 had significant diversions and out-of-order work. Sprint 2 completed cleanly in 7 days with full lifecycle. Sprint 3 hit a legitimate pivot but recovered systematically. The project is learning.
+
+4. **Knowledge Graph Under-Utilized:** 57 vertices, 12 hyperedges, but 2 open questions with zero investigation progress (QBP divergence, quaternionic path integrals). The knowledge graph is being populated but not actively queried for strategic insight.
+
+5. **Issue Backlog Growing:** 114 open issues, many pre-generated for future experiment phases. The housekeeping backlog (10+ items) is accumulating faster than it's being resolved.
+
+### Active Tensions
+
+| Tension | Description | Impact |
+|---------|-------------|--------|
+| **Reformulation vs. New Theory** | Moretti-Oppio proves equivalence for single-particle. Multi-particle is where divergence could appear — but also where QBP may become unphysical. | Existential for the project's scientific claims |
+| **Sprint 4 Readiness Gap** | Lamb Shift requires QED-level physics (vacuum fluctuations, self-interaction) with no quaternionic formulation | Sprint 4 cannot proceed without major theoretical development |
+| **Tsirelson Bound Dilemma** | Unrestricted quaternionic QM can simulate a PR-box (CHSH = 4.0), violating information causality | Sprint 6 may falsify QBP or force severe constraints |
+| **Falsifiability Asymmetry** | Single-particle predictions are unfalsifiable (match QM exactly). Multi-particle predictions may be falsified immediately. No middle ground. | Risk of the project producing elegant reformulation but no testable novelty |
+
+### Cross-Team Dependencies Not Yet in Plan
+
+- Theory Team needs to develop quaternionic tensor product formalism before Sprint 6 can be designed — this is not tracked as a research gate
+- Dev Team's BPM simulation engine (Sprint 3) will need significant extension for bound-state problems (Sprints 4, 8, 9)
+- Red Team has not been asked to attack the Moretti-Oppio interpretation — is the theorem's scope correctly understood?
+
+---
+
+## III. Axiomatic Risk Ledger
+
+| Axiom | Supporting Evidence | Contradictory Evidence | Confidence | Trend | Recommended Action |
+|-------|-------------------|----------------------|------------|-------|-------------------|
+| **A1: State (psi in Sp(1))** | Stern-Gerlach (0.41-sigma), Angle-Dependent (9 angles within 3-sigma), Lean 4 proofs | None | **85** | Stable | Continue verification. Next real test: multi-particle extension |
+| **A2: Observables (pure quaternion)** | Consistent with su(2) Lie algebra isomorphism, used successfully in all experiments | No test of observables outside spin-1/2 basis | **70** | Stable | Needs Bell test and higher-spin investigation |
+| **A3: Evolution (unitary)** | Symplectic decomposition in Sprint 3 uses this axiom; BPM simulation conserves probability | "Provisional" label in the paper; no Lean 4 proof for evolution | **65** | At risk | Formal verification of evolution axiom should be prioritized. Currently the least-proven axiom |
+| **A4: Measurement (Born rule + vecDot)** | cos^2(theta/2) proven in Lean 4; factor-of-2 correction validated | Only tested for single-particle spin-1/2 | **80** | Stable | Extend to spatial observables (Sprint 3 Phase 4) |
+
+**Strategic Alert Threshold:** No axiom is below 60. However, **A3 (Evolution)** at 65 is the closest to the threshold. It is the only axiom labeled "provisional" in the paper and the only one without formal verification. This should be addressed.
+
+---
+
+## IV. Experimental Prioritization
+
+### Current Roadmap Assessment
+
+| # | Experiment | Information Gain | Falsification Potential | Dependency Risk | Priority Score | Notes |
+|---|-----------|-----------------|------------------------|----------------|---------------|-------|
+| 03 | Double-Slit | **High** — first spatial wavefunction test, Adler decay prediction | **Medium** — novel prediction exists but constrained to tiny U_1 | Medium — BPM formalism used in later sprints | **8/10** | Continue as planned (current sprint) |
+| 06 | Bell's Theorem | **Critical** — only experiment that probes multi-particle regime | **Critical** — could falsify QBP entirely or confirm reformulation | **Very High** — requires solving tensor product problem | **10/10** | Should be elevated in priority. Consider pulling forward |
+| 04 | Lamb Shift | **Medium** — tests QED-level effects | **Low** — likely reproduces standard QM if formalism can be built | **Very High** — requires QBP field theory that doesn't exist | **4/10** | Major theoretical gap. May not be ready for years |
+| 05 | g-2 | **Medium** — precision test of radiative corrections | **Low** — same QED dependency as Lamb Shift | Very High | **3/10** | Depends on Sprint 4 formalism |
+| 07 | Particle Statistics | **High** — tests how QBP handles identical particles | **High** — spin-statistics theorem may not hold in quaternionic formalism | High — needs multi-particle framework | **7/10** | Could be attempted before Lamb Shift |
+| 08 | Positronium | **Medium** — first bound-state test | **Medium** — tests Coulomb + spin interaction | High | **5/10** | Intermediate step toward hydrogen |
+| 09 | Hydrogen Spectrum | **Medium** — classic QM validation | **Low** — will match standard QM | Medium | **4/10** | Less informative than Bell |
+| 10 | Gravity | **Aspirational** — would connect QBP to GR | **Unknown** — completely unexplored territory | Very High | **2/10** | No theoretical foundation exists |
+
+### Recommendation: Roadmap Resequencing
+
+**Current order:** 03 → 04 → 05 → 06 → 07 → 08 → 09 → 10
+
+**Proposed order:** 03 → **06** → **07** → 04 → 08 → 05 → 09 → 10
+
+**Rationale:** The project's existential question — is QBP a reformulation or a new theory? — is answered by Sprint 6 (Bell's Theorem). Every sprint between now and Sprint 6 that does not address this question is, strategically, a delay. Sprints 4 and 5 (Lamb Shift, g-2) require QED-level formalism that doesn't exist, while Sprint 6 requires only the tensor product problem — which is hard, but has prior literature. Sprint 7 (Particle Statistics) is a natural stepping stone toward multi-particle systems and can precede Bell.
+
+**This is a Level 2 recommendation.** Herschel should evaluate the sequencing against sprint infrastructure. James should be informed but immediate approval is not required.
+
+---
+
+## V. Cross-Functional Translation
+
+### For Theory Team (Gemini: Furey, Feynman)
+
+**Implementation Imperative:** The tensor product problem is now the project's rate-limiting theoretical challenge. Furey should investigate whether the Horwitz-Biedenharn quaternionic tensor product formalism or Adler's trace dynamics approach provides a path. Feynman should ask: "What is the simplest possible Bell experiment in quaternionic language, and what does it predict?"
+
+### For Red Team (Claude: Sabine, Grothendieck, Knuth)
+
+**Attack Vector Memo:** The Moretti-Oppio theorem is the project's strongest theoretical anchor. Sabine should verify: does the theorem's scope correctly exclude multi-particle systems, or does it extend further than we assume? Grothendieck should examine whether the categorical structure of quaternionic QM (monoidal categories, entanglement structure) is consistent. Knuth should audit the Sprint 3 BPM implementation for numerical stability at extreme parameter values.
+
+### For Dev Team (Claude: Carmack, Bret Victor, et al.)
+
+**Build Priorities:** After Sprint 3 Phase 3, begin scoping what a multi-particle simulation engine would require. The BPM framework handles single-particle propagation; Bell experiments need correlated two-particle state evolution. Bret Victor should consider: how do we visualize a quaternionic Bell experiment so that the tensor product problem becomes intuitive?
+
+### For Research Team (Claude: Curie, Poincare, et al.)
+
+**Investigation Brief:** Curie should conduct a literature survey on prior attempts at quaternionic Bell inequality analysis (start with Adler 1995, Chapter 3). Poincare should explore whether there is a "Goldilocks constraint" — a physically motivated restriction on quaternionic QM that preserves the Tsirelson bound while allowing non-trivial structure. Fisher should design the statistical framework for a simulated Bell test: how many trials, what detector settings, what significance threshold.
+
+---
+
+## VI. Project Summary and Recommendations
+
+### What Has Been Achieved (Sprints 1-3)
+
+1. **A rigorous axiomatic framework** (v0.1) for quaternionic quantum mechanics, with four axioms tested and three formally verified in Lean 4
+2. **Two complete experiments** (Stern-Gerlach, Angle-Dependent Measurement) passing all acceptance criteria with formal proofs
+3. **A novel prediction** (Adler decay / visibility recovery in double-slit Scenario C) currently being validated in Sprint 3
+4. **Honest confrontation** with the Moretti-Oppio equivalence theorem — the project knows what it is and what it isn't
+5. **World-class methodology**: pre-registered falsification criteria, adversarial multi-AI review, Lean 4 formal proofs, knowledge graph tracking, and automated differential testing against standard QM
+6. **A knowledge graph** with 57 vertices and 12 hyperedges tracking claims, sources, and relationships
+7. **An operational process** that has survived and improved through three sprints, including one major pivot
+
+### What Remains Unknown
+
+1. Whether QBP produces any experimentally distinguishable prediction (requires Sprints 6-7)
+2. Whether the quaternionic tensor product can be defined consistently (blocks Sprint 6)
+3. Whether the Adler decay prediction (Sprint 3, Scenario C) survives simulation testing
+4. Whether QBP can extend to QED-level phenomena (blocks Sprints 4-5)
+5. The connection to Furey's division algebra program for the Standard Model (long-term)
+
+### Strategic Recommendations
+
+**R1. Complete Sprint 3 as planned.** The double-slit experiment is the right next step. Finish Phase 3 (Visualization, #342), then Phases 4-5. Do not rush.
+
+**R2. Conduct a dedicated Research Sprint (1R) on the tensor product problem before Sprint 4.** This is the single most important theoretical question for the project's future. Allocate a full research sprint to surveying the literature (Adler, Horwitz-Biedenharn, Finkelstein), identifying candidate approaches, and assessing feasibility. The outcome determines whether Sprint 6 is achievable.
+
+**R3. Consider resequencing Sprints 4-7.** Pull Bell's Theorem (Sprint 6) and Particle Statistics (Sprint 7) forward. The Lamb Shift (Sprint 4) and g-2 (Sprint 5) require QED-level formalism that may take months or years to develop. Bell and particle statistics probe the multi-particle frontier that determines whether QBP has scientific novelty. Get to the existential question faster.
+
+**R4. Strengthen the Evolution axiom (A3).** It is the least-verified axiom (confidence 65, no formal proof, "provisional" label). A Lean 4 proof of the evolution axiom's consistency would cost relatively little and close a gap in the foundation.
+
+**R5. Activate the knowledge graph strategically.** Two high-priority questions (QBP divergence, quaternionic path integrals) have zero investigation progress. Use the gaps analysis to drive Research Team priorities.
+
+**R6. Address the Tsirelson bound question early.** Before investing in Sprint 6 implementation, have Theory Team produce a position paper on whether quaternionic QM necessarily violates the Tsirelson bound and, if so, what constraints could prevent it. This is the project's highest-risk item: if the answer is "QBP necessarily violates information causality," the project must decide how to respond before committing to the Bell experiment.
+
+### The Bottom Line
+
+*QBP has built a cathedral of process on a foundation that, so far, is confirmed solid but indistinguishable from the building next door. The next 2-3 sprints will determine whether this cathedral has a unique address. The key is not to delay that determination by routing through problems (Lamb Shift, g-2) that require theoretical machinery the project does not yet possess, when the existential question (Bell's Theorem) is answerable with less — though still formidable — theoretical development.*
+
+*The recommendation is clear: finish the double-slit, research the tensor product, then go straight to the experiments that will tell us whether we are building something new or something beautiful.*
+
+---
+
+**Oppenheimer**
+Strategic AI Project Lead
+QBP Initiative

--- a/docs/verification/vv_checklist_03.md
+++ b/docs/verification/vv_checklist_03.md
@@ -1,0 +1,47 @@
+# V&V Checklist — Experiment 03: Double-Slit
+
+**Issue:** #302 (Phase 4e)
+**Sprint:** 3
+**Date:** 2026-02-21
+
+## Setup Verification
+
+| # | Check | Expected | Actual | Pass |
+|---|-------|----------|--------|------|
+| 1 | Lab room loads without crash | 3D room visible, 4000+ FPS | | [ ] |
+| 2 | Optical bench visible | Source, barrier, detector on bench | | [ ] |
+| 3 | Double-slit barrier has two visible gaps | Two slits in brass barrier plate | | [ ] |
+| 4 | Detector screen visible | Ivory panel at +X end of bench | | [ ] |
+
+## Behavior Verification
+
+| # | Check | Expected | Actual | Pass |
+|---|-------|----------|--------|------|
+| 5 | Emitter starts on launch | Particles accumulate on detector | | [ ] |
+| 6 | Enter toggles start/stop | Particles stop/resume on Enter key | | [ ] |
+| 7 | Slit separation slider works | Dragging slider changes d value | | [ ] |
+| 8 | Slider resets detector | Changing d clears accumulated hits | | [ ] |
+| 9 | Preset keys apply parameters | 5=Bach, 6=Zeilinger, 7=Tonomura | | [ ] |
+| 10 | Oracle overlay toggles | O key shows/hides Fraunhofer curve | | [ ] |
+| 11 | R key resets detector | Clears all accumulated particles | | [ ] |
+
+## Results Validation
+
+| # | Check | Expected | Actual | Pass |
+|---|-------|----------|--------|------|
+| 12 | V&V verdict on preset | N>1000 → PASS (fringe spacing within 5%) | | [ ] |
+| 13 | Custom params show UNVALIDATED | Moving slider away from preset | | [ ] |
+
+## Acceptance Criteria (from #302)
+
+- [ ] **AC1:** Go simulation scene implemented for Experiment 03
+- [ ] **AC2:** Physics oracle provides Lean-proven predictions
+- [ ] **AC3:** Human can manipulate experiment setup parameters
+- [ ] **AC4:** V&V checklist documented and completed
+
+## Sign-off
+
+| Role | Name | Date |
+|------|------|------|
+| Developer | Claude (Herschel) | |
+| Reviewer | James | |

--- a/research/03_double_slit_expected_results.md
+++ b/research/03_double_slit_expected_results.md
@@ -9,7 +9,21 @@ This document defines the quantitative predictions for the double-slit interfere
 
 ## 1. Experimental Setup
 
-### 1.1 Apparatus Parameters (SI)
+### 1.1 Environmental Conditions (REQUIRED)
+
+| Parameter | Ambient Baseline | Lab-Specific Alteration | Rationale |
+|-----------|------------------|-------------------------|-----------|
+| **Temperature** | 295.15 K (22°C) | 295.15 K (Standard) | Stability required for electron gun optics. |
+| **Pressure** | 1.0 atm | **1.0 × 10⁻⁷ Pa (High Vacuum)** | Crucial to prevent scattering by air molecules, which would decohere the wavefunction and wash out the interference pattern. |
+| **Atmosphere** | **Old Growth Forest** | **High Vacuum (None)** | Atmosphere must be completely evacuated for electron propagation. |
+| **Gravity** | 9.81 m/s² | 9.81 m/s² (Standard) | No significant impact on non-relativistic electron propagation at this scale. |
+
+**Airlock/Safety Protocols:**
+- **Access:** Mandatory entry via a three-cycle airlock system to maintain the high-vacuum environment.
+- **Protective Gear:** All personnel must wear full vacuum-rated suits with independent life support. Entering the lab without such gear results in immediate decompression and termination of the experiment.
+- **Protocol:** Pre-entry briefing includes a review of the "Ambient Baseline" vs. "Lab-Specific Alteration" status on the doorway LED panel.
+
+### 1.2 Apparatus Parameters (SI)
 
 | Parameter | Symbol | SI Value | Unit | Source |
 |-----------|--------|----------|------|--------|

--- a/src/bakeoff/kaiju/.gitignore
+++ b/src/bakeoff/kaiju/.gitignore
@@ -1,0 +1,17 @@
+# Kaiju engine (vendored git repo — not tracked in QBP repo)
+# Clone separately: see README.md for setup instructions.
+engine/
+
+# Build artifacts
+kaiju-ds
+*.o
+*.a
+
+# Shared libraries (platform-specific, symlinked at build time)
+local_libs/
+
+# Symlinks to engine content
+content
+
+# Runtime artifacts
+fps_log.txt

--- a/src/bakeoff/kaiju/README.md
+++ b/src/bakeoff/kaiju/README.md
@@ -1,0 +1,63 @@
+# Kaiju Engine — QBP Virtual Lab
+
+3D double-slit experiment visualization using the [Kaiju engine](https://github.com/KaijuEngine/kaiju) (Go/Vulkan).
+
+## Directory Layout
+
+```
+kaiju/
+├── game/           # QBP lab game source (tracked in this repo)
+├── engine/         # Kaiju engine clone (gitignored, see Setup)
+├── local_libs/     # Symlinked Vulkan/ALSA .so files (gitignored)
+├── kaiju-ds        # Built binary (gitignored)
+└── content -> engine/src/content
+```
+
+## Setup
+
+```bash
+# 1. Clone Kaiju engine into engine/
+cd src/bakeoff/kaiju
+git clone --depth 1 https://github.com/KaijuEngine/kaiju.git engine
+
+# 2. Copy game source files into engine src (they build alongside engine code)
+cp game/*.go engine/src/
+
+# 3. Symlink Vulkan and ALSA libraries
+mkdir -p local_libs
+ln -sf /usr/lib/x86_64-linux-gnu/libvulkan.so local_libs/libvulkan.so
+ln -sf /usr/lib/x86_64-linux-gnu/libasound.so local_libs/libasound.so
+
+# 4. Symlink content directory
+ln -sf engine/src/content content
+
+# 5. Build
+cd engine/src
+CGO_LDFLAGS="-L$(pwd)/../../local_libs -Wl,-rpath,$(pwd)/../../local_libs" \
+  go build -tags '!editor' -o ../../kaiju-ds .
+
+# 6. Run
+cd ../..
+QBP_LAB=1 LD_LIBRARY_PATH=./local_libs ./kaiju-ds
+```
+
+## Controls
+
+### Desk Controls (FPS crosshair — aim + click)
+- **START/STOP**: Toggle particle emitter
+- **RATE +/-**: Adjust emission rate (×10 / ÷10)
+- **RESET**: Clear detector
+- **ORACLE**: Toggle measurement overlay
+- **Presets**: Bach, Zeilinger, Tonomura, QBP-weak, QBP-strong
+- **SLIT dial**: Click-lock, scroll to adjust slit separation
+
+### Keyboard Shortcuts
+- `Enter` — Start/Stop emitter
+- `Space` — Freeze particles
+- `+/-` — Rate up/down
+- `5-9` — Presets
+- `O` — Oracle toggle
+- `R` — Reset detector
+- `Q` — Sit/Stand
+- `H` — Toggle hotkey help strip
+- `ESC` — Quit

--- a/src/bakeoff/kaiju/game/desk_controls.go
+++ b/src/bakeoff/kaiju/game/desk_controls.go
@@ -1,0 +1,339 @@
+//go:build !editor
+
+// QBP Phase 4e — Desk Controls
+//
+// Physical buttons and dials on the desk surface that the scientist
+// interacts with via FPS crosshair raycast (Minecraft/Portal style).
+// Hover highlights the control; click triggers the callback.
+
+package main
+
+import (
+	"kaiju/engine"
+	"kaiju/engine/assets"
+	"kaiju/engine/collision"
+	"kaiju/matrix"
+	"kaiju/platform/hid"
+	"kaiju/registry/shader_data_registry"
+	"kaiju/rendering"
+)
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+// DeskControl represents a single interactive control on the desk surface.
+type DeskControl struct {
+	ID         string
+	AABB       collision.AABB
+	Entity     *engine.Entity
+	SD         *shader_data_registry.ShaderDataUnlit
+	BaseColor  matrix.Color
+	HoverColor matrix.Color
+	OnClick    func()
+	IsToggle   bool // For toggle-style controls (oracle)
+	IsActive   bool // Current toggle state
+}
+
+// DeskControlManager manages all desk controls and handles raycast interaction.
+type DeskControlManager struct {
+	host     *engine.Host
+	controls []*DeskControl
+	aimed    *DeskControl // Currently hovered
+
+	// Click-lock state for dial controls
+	dialLocked   bool
+	lockedDial   *DeskControl
+	dialCallback func(delta float32) // Called with mouse Y delta when dial is locked
+}
+
+// LabControlCallbacks provides the functions to wire up to desk controls.
+type LabControlCallbacks struct {
+	OnStartStop    func()
+	OnRateUp       func()
+	OnRateDown     func()
+	OnReset        func()
+	OnOracleToggle func()
+	OnPreset       func(id string)
+	OnSlitDial     func(delta float32) // delta in scroll units
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+// brightenColor mixes base toward white by the given factor (0..1).
+func brightenColor(base matrix.Color, factor float32) matrix.Color {
+	r := base.R() + (1-base.R())*factor
+	g := base.G() + (1-base.G())*factor
+	b := base.B() + (1-base.B())*factor
+	return matrix.NewColor(r, g, b, 1)
+}
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+// NewDeskControlManager creates a new manager (no controls yet).
+func NewDeskControlManager(host *engine.Host) *DeskControlManager {
+	return &DeskControlManager{
+		host:     host,
+		controls: make([]*DeskControl, 0, 16),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Adding controls
+// ---------------------------------------------------------------------------
+
+// AddButton creates a cube button entity sitting on the desk surface.
+func (m *DeskControlManager) AddButton(
+	id string,
+	posX, posZ float32,
+	size float32,
+	baseColor matrix.Color,
+	onClick func(),
+) *DeskControl {
+	host := m.host
+
+	// Position: sits on desk surface, slightly raised
+	pos := matrix.NewVec3(posX, deskY+size/2+0.01, posZ)
+	scale := matrix.NewVec3(size, size, size)
+
+	// Create entity + drawing
+	mesh := rendering.NewMeshCube(host.MeshCache())
+	entity := engine.NewEntity(host.WorkGroup())
+	entity.Transform.SetPosition(pos)
+	entity.Transform.SetScale(scale)
+
+	mat, _ := host.MaterialCache().Material(assets.MaterialDefinitionUnlit)
+	sd := &shader_data_registry.ShaderDataUnlit{
+		ShaderDataBase: rendering.NewShaderDataBase(),
+		Color:          baseColor,
+		UVs:            matrix.NewVec4(0, 0, 1, 1),
+	}
+	drawing := rendering.Drawing{
+		Material:   mat,
+		Mesh:       mesh,
+		Transform:  &entity.Transform,
+		ShaderData: sd,
+		ViewCuller: &host.Cameras.Primary,
+	}
+	host.Drawings.AddDrawing(drawing)
+
+	// AABB: extended upward by 0.05 for easier targeting from steep angles
+	aabb := collision.AABB{
+		Center: pos,
+		Extent: matrix.NewVec3(size/2+0.02, size/2+0.05, size/2+0.02),
+	}
+
+	hoverColor := brightenColor(baseColor, 0.4)
+
+	ctrl := &DeskControl{
+		ID:         id,
+		AABB:       aabb,
+		Entity:     entity,
+		SD:         sd,
+		BaseColor:  baseColor,
+		HoverColor: hoverColor,
+		OnClick:    onClick,
+	}
+	m.controls = append(m.controls, ctrl)
+	return ctrl
+}
+
+// AddDial creates a wider/flatter cube for dial-style controls (e.g. slit separation).
+func (m *DeskControlManager) AddDial(
+	id string,
+	posX, posZ float32,
+	sizeX, sizeZ float32,
+	baseColor matrix.Color,
+	onScroll func(delta float32),
+) *DeskControl {
+	host := m.host
+
+	// Position: thin, nearly flush with desk
+	pos := matrix.NewVec3(posX, deskY+0.02, posZ)
+	scale := matrix.NewVec3(sizeX, 0.02, sizeZ)
+
+	// Create entity + drawing
+	mesh := rendering.NewMeshCube(host.MeshCache())
+	entity := engine.NewEntity(host.WorkGroup())
+	entity.Transform.SetPosition(pos)
+	entity.Transform.SetScale(scale)
+
+	mat, _ := host.MaterialCache().Material(assets.MaterialDefinitionUnlit)
+	sd := &shader_data_registry.ShaderDataUnlit{
+		ShaderDataBase: rendering.NewShaderDataBase(),
+		Color:          baseColor,
+		UVs:            matrix.NewVec4(0, 0, 1, 1),
+	}
+	drawing := rendering.Drawing{
+		Material:   mat,
+		Mesh:       mesh,
+		Transform:  &entity.Transform,
+		ShaderData: sd,
+		ViewCuller: &host.Cameras.Primary,
+	}
+	host.Drawings.AddDrawing(drawing)
+
+	// AABB: extended upward for easier targeting
+	aabb := collision.AABB{
+		Center: pos,
+		Extent: matrix.NewVec3(sizeX/2+0.02, 0.01+0.05, sizeZ/2+0.02),
+	}
+
+	hoverColor := brightenColor(baseColor, 0.4)
+
+	// The OnClick for a dial toggles the click-lock
+	scrollCb := onScroll
+	ctrl := &DeskControl{
+		ID:         id,
+		AABB:       aabb,
+		Entity:     entity,
+		SD:         sd,
+		BaseColor:  baseColor,
+		HoverColor: hoverColor,
+	}
+	// Wire click to toggle the dial lock on the manager
+	ctrl.OnClick = func() {
+		if m.dialLocked && m.lockedDial == ctrl {
+			// Release
+			m.dialLocked = false
+			m.lockedDial = nil
+			m.dialCallback = nil
+		} else {
+			// Grab
+			m.dialLocked = true
+			m.lockedDial = ctrl
+			m.dialCallback = scrollCb
+		}
+	}
+
+	m.controls = append(m.controls, ctrl)
+	return ctrl
+}
+
+// ---------------------------------------------------------------------------
+// Per-frame update
+// ---------------------------------------------------------------------------
+
+// Update performs per-frame raycast hit-testing and interaction.
+// Returns the currently aimed control (or nil), useful for crosshair color.
+func (m *DeskControlManager) Update(host *engine.Host) *DeskControl {
+	mouse := &host.Window.Mouse
+
+	// --- Dial lock mode ---
+	if m.dialLocked && m.dialCallback != nil {
+		// Apply scroll wheel as dial input
+		scrollDelta := mouse.ScrollY
+		if scrollDelta != 0 {
+			m.dialCallback(scrollDelta)
+		}
+
+		// Click releases the dial lock
+		if mouse.Pressed(hid.MouseButtonLeft) {
+			m.dialLocked = false
+			m.lockedDial = nil
+			m.dialCallback = nil
+		}
+		return m.lockedDial
+	}
+
+	// --- Normal mode: raycast from screen center ---
+	cam := host.PrimaryCamera()
+	w, h := host.Window.Width(), host.Window.Height()
+	screenCenter := matrix.NewVec2(float32(w)/2, float32(h)/2)
+	ray := cam.RayCast(screenCenter)
+
+	// Hit-test all controls, pick the closest hit
+	var closest *DeskControl
+	var closestDist matrix.Float = 1e9
+
+	for _, ctrl := range m.controls {
+		hitPos, hit := ctrl.AABB.RayHit(ray)
+		if hit {
+			dist := ray.Origin.Distance(hitPos)
+			if dist < closestDist {
+				closestDist = dist
+				closest = ctrl
+			}
+		}
+	}
+
+	// Hover state transitions
+	if closest != m.aimed {
+		// Unhighlight old
+		if m.aimed != nil {
+			m.aimed.SD.Color = m.aimed.BaseColor
+		}
+		// Highlight new
+		if closest != nil {
+			closest.SD.Color = closest.HoverColor
+		}
+		m.aimed = closest
+	}
+
+	// Click handling
+	if mouse.Pressed(hid.MouseButtonLeft) && m.aimed != nil {
+		if m.aimed.IsToggle {
+			m.aimed.IsActive = !m.aimed.IsActive
+		}
+		if m.aimed.OnClick != nil {
+			m.aimed.OnClick()
+		}
+	}
+
+	return m.aimed
+}
+
+// ---------------------------------------------------------------------------
+// Lab control layout
+// ---------------------------------------------------------------------------
+
+// SetupLabControls creates all the standard desk controls for the QBP lab.
+func (m *DeskControlManager) SetupLabControls(callbacks LabControlCallbacks) {
+	const controlZ float32 = deskZ + 0.35 // -5.15
+
+	// RESET
+	m.AddButton("reset", -0.30, controlZ, 0.05,
+		labColCopper(), callbacks.OnReset)
+
+	// SLIT DIAL (wider/flatter)
+	m.AddDial("slit_dial", -0.18, controlZ, 0.10, 0.06,
+		labColBrass(), callbacks.OnSlitDial)
+
+	// RATE -
+	m.AddButton("rate_down", -0.06, controlZ, 0.04,
+		labColBrass(), callbacks.OnRateDown)
+
+	// RATE +
+	m.AddButton("rate_up", 0.00, controlZ, 0.04,
+		labColBrass(), callbacks.OnRateUp)
+
+	// START/STOP (green)
+	m.AddButton("start_stop", 0.10, controlZ, 0.08,
+		matrix.NewColor(0.3, 0.9, 0.4, 1), callbacks.OnStartStop)
+
+	// Preset buttons: Bach, Zeilinger, Tonomura
+	m.AddButton("bach_2013", 0.22, controlZ, 0.03,
+		labColSteel(), func() { callbacks.OnPreset("bach_2013") })
+
+	m.AddButton("zeilinger_1988", 0.26, controlZ, 0.03,
+		labColSteel(), func() { callbacks.OnPreset("zeilinger_1988") })
+
+	m.AddButton("tonomura_1989", 0.30, controlZ, 0.03,
+		labColSteel(), func() { callbacks.OnPreset("tonomura_1989") })
+
+	// QBP preset buttons
+	m.AddButton("qbp_weak", 0.34, controlZ, 0.03,
+		labColAmber(), func() { callbacks.OnPreset("qbp_weak") })
+
+	m.AddButton("qbp_strong", 0.38, controlZ, 0.03,
+		labColAmber(), func() { callbacks.OnPreset("qbp_strong") })
+
+	// ORACLE (toggle)
+	oracle := m.AddButton("oracle", 0.46, controlZ, 0.05,
+		matrix.NewColor(0.3, 0.5, 0.8, 1), callbacks.OnOracleToggle)
+	oracle.IsToggle = true
+}

--- a/src/bakeoff/kaiju/game/desk_controls.go
+++ b/src/bakeoff/kaiju/game/desk_controls.go
@@ -337,75 +337,57 @@ func (m *DeskControlManager) Update(host *engine.Host) *DeskControl {
 // most critical (START/STOP) largest and leftmost, adjustment dials center,
 // presets right wing.
 func (m *DeskControlManager) SetupLabControls(callbacks LabControlCallbacks) {
-	const controlZ float32 = deskZ + 0.25 // -5.25 (slightly back from old position)
+	const controlZ float32 = deskZ + 0.25
 
-	// ═══════════════════════════════════════════════════════════
-	// GROUP 1: EXPERIMENT (center-left)
-	// ═══════════════════════════════════════════════════════════
-	const expX float32 = -0.90
+	// ═══ GROUP 1: EXPERIMENT (center-left) ═══
+	const expX float32 = -0.55
 
-	// START/STOP — large green button (most important control)
-	m.AddButton("start_stop", expX, controlZ, 0.10,
+	m.AddButton("start_stop", expX, controlZ, 0.06,
 		matrix.NewColor(0.2, 0.85, 0.3, 1), callbacks.OnStartStop)
 
-	// RESET — medium red button
-	m.AddButton("reset", expX+0.18, controlZ, 0.06,
+	m.AddButton("reset", expX+0.12, controlZ, 0.04,
 		matrix.NewColor(0.85, 0.15, 0.15, 1), callbacks.OnReset)
 
-	// ORACLE — medium blue toggle
-	oracle := m.AddButton("oracle", expX+0.32, controlZ, 0.06,
+	oracle := m.AddButton("oracle", expX+0.22, controlZ, 0.04,
 		matrix.NewColor(0.3, 0.5, 0.85, 1), callbacks.OnOracleToggle)
 	oracle.IsToggle = true
 
-	// ═══════════════════════════════════════════════════════════
-	// GROUP 2: PARAMETERS (center)
-	// ═══════════════════════════════════════════════════════════
-	const paramX float32 = -0.15
+	// ═══ GROUP 2: PARAMETERS (center) ═══
+	const paramX float32 = -0.10
 
-	// RATE -
-	m.AddButton("rate_down", paramX, controlZ, 0.04,
+	m.AddButton("rate_down", paramX, controlZ, 0.03,
 		labColBrass(), callbacks.OnRateDown)
 
-	// RATE +
-	m.AddButton("rate_up", paramX+0.08, controlZ, 0.04,
+	m.AddButton("rate_up", paramX+0.06, controlZ, 0.03,
 		labColBrass(), callbacks.OnRateUp)
 
-	// SLIT DIAL — wide/flat brass dial
-	m.AddDial("slit_dial", paramX+0.22, controlZ, 0.10, 0.06,
+	m.AddDial("slit_dial", paramX+0.16, controlZ, 0.08, 0.04,
 		labColBrass(), callbacks.OnSlitDial)
 
-	// CAP — cycle particle cap
-	m.AddButton("cap_cycle", paramX+0.38, controlZ, 0.04,
+	m.AddButton("cap_cycle", paramX+0.28, controlZ, 0.03,
 		labColBrass(), callbacks.OnCapCycle)
 
-	// ═══════════════════════════════════════════════════════════
-	// GROUP 3: PRESETS (right wing)
-	// ═══════════════════════════════════════════════════════════
-	const presetX float32 = 0.55
+	// ═══ GROUP 3: PRESETS (right) ═══
+	const presetX float32 = 0.35
 
-	// Standard QM presets (steel colored)
-	m.AddButton("bach_2013", presetX, controlZ, 0.04,
+	m.AddButton("bach_2013", presetX, controlZ, 0.03,
 		labColSteel(), func() { callbacks.OnPreset("bach_2013") })
 
-	m.AddButton("zeilinger_1988", presetX+0.07, controlZ, 0.04,
+	m.AddButton("zeilinger_1988", presetX+0.06, controlZ, 0.03,
 		labColSteel(), func() { callbacks.OnPreset("zeilinger_1988") })
 
-	m.AddButton("tonomura_1989", presetX+0.14, controlZ, 0.04,
+	m.AddButton("tonomura_1989", presetX+0.12, controlZ, 0.03,
 		labColSteel(), func() { callbacks.OnPreset("tonomura_1989") })
 
-	// QBP presets (amber — "caution: quaternionic")
-	m.AddButton("qbp_weak", presetX+0.23, controlZ, 0.04,
+	m.AddButton("qbp_weak", presetX+0.20, controlZ, 0.03,
 		labColAmber(), func() { callbacks.OnPreset("qbp_weak") })
 
-	m.AddButton("qbp_strong", presetX+0.30, controlZ, 0.04,
+	m.AddButton("qbp_strong", presetX+0.26, controlZ, 0.03,
 		labColAmber(), func() { callbacks.OnPreset("qbp_strong") })
 
-	// ═══════════════════════════════════════════════════════════
-	// GROUP LABELS (3D SDF text above each zone)
-	// ═══════════════════════════════════════════════════════════
-	const labelZ float32 = controlZ - 0.08 // In front of controls (toward scientist)
-
-	m.AddLabel("EXPERIMENT", expX+0.16, labelZ, 0.015)
-	m.AddLabel("PARAMETERS", paramX+0.19, labelZ, 0.015)
-	m.AddLabel("PRESETS", presetX+0.15, labelZ, 0.015)
+	// ═══ GROUP LABELS ═══
+	const labelZ float32 = controlZ - 0.06
+	m.AddLabel("EXPERIMENT", expX+0.11, labelZ, 0.012)
+	m.AddLabel("PARAMETERS", paramX+0.14, labelZ, 0.012)
+	m.AddLabel("PRESETS", presetX+0.13, labelZ, 0.012)
 }

--- a/src/bakeoff/kaiju/game/doubleslit_game.go
+++ b/src/bakeoff/kaiju/game/doubleslit_game.go
@@ -1,0 +1,582 @@
+//go:build !editor
+
+// Double-Slit Bake-Off Prototype — Kaiju Engine
+//
+// Minimal double-slit simulation exercising: 3D scene on a lab bench,
+// particle accumulation (Tonomura-style), 2D text overlay,
+// FPS camera, and QBP design system colors.
+
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"kaiju/bootstrap"
+	"kaiju/engine"
+	"kaiju/engine/assets"
+	"kaiju/matrix"
+	"kaiju/platform/hid"
+	"kaiju/registry/shader_data_registry"
+	"kaiju/rendering"
+	"math"
+	"math/rand"
+	"os"
+	"os/signal"
+	"reflect"
+	"runtime"
+	"syscall"
+	"strconv"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Design System Colors (from docs/design-system.md)
+// ---------------------------------------------------------------------------
+
+func colMidnight() matrix.Color     { return matrix.NewColor(13.0/255, 27.0/255, 42.0/255, 1) }
+func colBrass() matrix.Color        { return matrix.NewColor(212.0/255, 165.0/255, 116.0/255, 1) }
+func colCopper() matrix.Color       { return matrix.NewColor(184.0/255, 115.0/255, 51.0/255, 1) }
+func colBronze() matrix.Color       { return matrix.NewColor(205.0/255, 127.0/255, 50.0/255, 1) }
+func colSteel() matrix.Color        { return matrix.NewColor(113.0/255, 121.0/255, 126.0/255, 1) }
+func colGold() matrix.Color         { return matrix.NewColor(1, 215.0/255, 0, 1) }
+
+// Suppress unused warnings
+var _ = colGold
+
+// ---------------------------------------------------------------------------
+// Benchmark Mode
+// ---------------------------------------------------------------------------
+
+var dsBenchmarkMode = false
+var dsBenchCheckpoints = []int{100, 500, 1000, 5000, 10000, 25000}
+
+type dsBenchCheckpoint struct {
+	Particles   int
+	FPS         float32
+	FrameTimeMs float32
+	RSSMb       float64
+}
+
+func dsGetRSSMb() float64 {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return float64(m.Sys) / 1024 / 1024
+}
+
+func dsWriteBenchCSV(filename string, results []dsBenchCheckpoint, totalTime time.Duration) {
+	f, err := os.Create(filename)
+	if err != nil {
+		fmt.Printf("Error creating benchmark file: %v\n", err)
+		return
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	defer w.Flush()
+
+	w.Write([]string{"engine", "particles", "fps", "frame_time_ms", "rss_mb"})
+	for _, r := range results {
+		w.Write([]string{
+			"kaiju",
+			strconv.Itoa(r.Particles),
+			fmt.Sprintf("%.1f", r.FPS),
+			fmt.Sprintf("%.2f", r.FrameTimeMs),
+			fmt.Sprintf("%.1f", r.RSSMb),
+		})
+	}
+
+	fmt.Printf("\nKaiju benchmark complete in %v — %d checkpoints written to %s\n",
+		totalTime.Round(time.Millisecond), len(results), filename)
+}
+
+func init() {
+	// Kaiju's bootstrap uses flag package, so we use an env var instead
+	if os.Getenv("QBP_BENCHMARK") == "1" {
+		dsBenchmarkMode = true
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Physics Engine
+// ---------------------------------------------------------------------------
+
+const (
+	dsDefaultSlitSep    = 1.0e-6
+	dsDefaultWavelength = 5.0e-11
+	dsDefaultScreenDist = 1.0
+	dsDefaultSlitWidth  = 1.0e-7
+	dsHistBins          = 100
+)
+
+type dsPhysicsEngine struct {
+	SlitSep    float64
+	Wavelength float64
+	ScreenDist float64
+	SlitWidth  float64
+	rng        *rand.Rand
+}
+
+func newDSPhysicsEngine() *dsPhysicsEngine {
+	return &dsPhysicsEngine{
+		SlitSep:    dsDefaultSlitSep,
+		Wavelength: dsDefaultWavelength,
+		ScreenDist: dsDefaultScreenDist,
+		SlitWidth:  dsDefaultSlitWidth,
+		rng:        rand.New(rand.NewSource(42)),
+	}
+}
+
+func (e *dsPhysicsEngine) FringeSpacing() float64 {
+	return e.Wavelength * e.ScreenDist / e.SlitSep
+}
+
+func (e *dsPhysicsEngine) Intensity(x float64) float64 {
+	argD := math.Pi * e.SlitSep * x / (e.Wavelength * e.ScreenDist)
+	argA := math.Pi * e.SlitWidth * x / (e.Wavelength * e.ScreenDist)
+	cos2 := math.Cos(argD) * math.Cos(argD)
+	sinc2 := 1.0
+	if math.Abs(argA) > 1e-12 {
+		s := math.Sin(argA) / argA
+		sinc2 = s * s
+	}
+	return cos2 * sinc2
+}
+
+func (e *dsPhysicsEngine) SampleHitPosition() float64 {
+	halfWidth := 5.0 * e.FringeSpacing()
+	for {
+		x := (e.rng.Float64()*2 - 1) * halfWidth
+		if e.rng.Float64() < e.Intensity(x) {
+			return x
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Coordinate Mapper
+// ---------------------------------------------------------------------------
+
+type dsCoordMapper struct {
+	PhysHalfWidth float64
+	NDUHalfWidth  matrix.Float
+}
+
+func newDSCoordMapper(fringeSpacing float64) *dsCoordMapper {
+	return &dsCoordMapper{PhysHalfWidth: 5.0 * fringeSpacing, NDUHalfWidth: 5.0}
+}
+
+func (cm *dsCoordMapper) PhysToNDU(x float64) matrix.Float {
+	return matrix.Float(x/cm.PhysHalfWidth) * cm.NDUHalfWidth
+}
+
+func (cm *dsCoordMapper) Update(fringeSpacing float64) {
+	cm.PhysHalfWidth = 5.0 * fringeSpacing
+}
+
+// ---------------------------------------------------------------------------
+// Particle System
+// ---------------------------------------------------------------------------
+
+type dsScreenHit struct {
+	NDUX matrix.Float
+	NDUY matrix.Float
+}
+
+type dsParticleSystem struct {
+	Hits      []dsScreenHit
+	Histogram [dsHistBins]int
+	engine    *dsPhysicsEngine
+	mapper    *dsCoordMapper
+	emitRate  float32
+	emitTimer float32
+	rng       *rand.Rand
+}
+
+func newDSParticleSystem(eng *dsPhysicsEngine, mapper *dsCoordMapper) *dsParticleSystem {
+	return &dsParticleSystem{
+		Hits:     make([]dsScreenHit, 0, 10000),
+		engine:   eng,
+		mapper:   mapper,
+		emitRate: 50,
+		rng:      rand.New(rand.NewSource(99)),
+	}
+}
+
+func (ps *dsParticleSystem) Update(dt float32) {
+	ps.emitTimer += dt
+	interval := 1.0 / ps.emitRate
+	for ps.emitTimer >= interval {
+		ps.emitTimer -= interval
+		x := ps.engine.SampleHitPosition()
+		ndux := ps.mapper.PhysToNDU(x)
+		nduy := matrix.Float(ps.rng.Float64()-0.5) * 0.3
+		ps.Hits = append(ps.Hits, dsScreenHit{NDUX: ndux, NDUY: nduy})
+
+		t := (x/ps.mapper.PhysHalfWidth + 1) / 2
+		bin := int(t * dsHistBins)
+		if bin < 0 {
+			bin = 0
+		}
+		if bin >= dsHistBins {
+			bin = dsHistBins - 1
+		}
+		ps.Histogram[bin]++
+	}
+}
+
+func (ps *dsParticleSystem) Reset() {
+	ps.Hits = ps.Hits[:0]
+	ps.Histogram = [dsHistBins]int{}
+}
+
+// ---------------------------------------------------------------------------
+// Game Implementation
+// ---------------------------------------------------------------------------
+
+type DoubleslitGame struct {
+	host      *engine.Host
+	physEng   *dsPhysicsEngine
+	mapper    *dsCoordMapper
+	particles *dsParticleSystem
+
+	// Camera state
+	yaw      matrix.Float
+	pitch    matrix.Float
+	speed    matrix.Float
+	lastMX   float32
+	lastMY   float32
+	hasLastM bool
+
+	// Slider
+	sliderVal float32
+
+	paused    bool
+	heartbeat chan struct{}
+
+	// Hit entities for rendering
+	hitEntities []*engine.Entity
+
+	// Benchmark state
+	benchResults       []dsBenchCheckpoint
+	nextCheckpointIdx  int
+	benchStart         time.Time
+	frameTimeAccum     float32
+	frameCount         int
+}
+
+func (g *DoubleslitGame) PluginRegistry() []reflect.Type {
+	return []reflect.Type{}
+}
+
+func (g *DoubleslitGame) ContentDatabase() (assets.Database, error) {
+	return assets.NewFileDatabase("content")
+}
+
+func (g *DoubleslitGame) Launch(host *engine.Host) {
+	g.host = host
+	g.physEng = newDSPhysicsEngine()
+	g.mapper = newDSCoordMapper(g.physEng.FringeSpacing())
+	g.particles = newDSParticleSystem(g.physEng, g.mapper)
+	g.yaw = -math.Pi / 2
+	g.pitch = -0.15
+	g.speed = 8.0
+	g.sliderVal = 0.5
+
+	// Set up camera
+	cam := host.PrimaryCamera()
+	cam.SetPosition(matrix.NewVec3(0, 3, 18))
+
+	// Create 3D scene objects
+	g.createLabBench(host)
+	g.createApparatus(host)
+
+	if dsBenchmarkMode {
+		g.particles.emitRate = 10000
+		g.benchStart = time.Now()
+	}
+
+	// Watchdog: SIGUSR1 force-kills if GPU hangs and ESC can't fire.
+	// From another terminal: kill -USR1 $(pgrep kaiju-ds)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGUSR1)
+	go func() {
+		<-sigCh
+		fmt.Println("SIGUSR1 received — force quit (watchdog)")
+		os.Exit(1)
+	}()
+
+	// Heartbeat watchdog: if the update loop stops ticking for 5 seconds
+	// (GPU hang), force-kill the process. This runs in a separate goroutine
+	// so it works even when the render pipeline is frozen.
+	g.heartbeat = make(chan struct{}, 1)
+	go func() {
+		for {
+			select {
+			case <-g.heartbeat:
+				// Game loop is alive, reset timer
+			case <-time.After(5 * time.Second):
+				fmt.Println("WATCHDOG: update loop stalled for 5s — force quit")
+				os.Exit(1)
+			}
+		}
+	}()
+
+	// Register update loop
+	host.Updater.AddUpdate(func(deltaTime float64) {
+		// Signal watchdog that we're alive
+		select {
+		case g.heartbeat <- struct{}{}:
+		default:
+		}
+		g.update(matrix.Float(deltaTime))
+	})
+
+	if dsBenchmarkMode {
+		fmt.Println("QBP Double-Slit Bake-Off — Kaiju BENCHMARK MODE")
+		fmt.Printf("Checkpoints: %v particles\n", dsBenchCheckpoints)
+	} else {
+		fmt.Println("QBP Double-Slit Bake-Off — Kaiju Engine Prototype")
+		fmt.Println("WASD: move | Mouse: look | Space: pause | R: reset | ESC: quit")
+	}
+}
+
+func (g *DoubleslitGame) createCube(host *engine.Host, pos, scale matrix.Vec3, color matrix.Color) {
+	mesh := rendering.NewMeshCube(host.MeshCache())
+	entity := engine.NewEntity(host.WorkGroup())
+	entity.Transform.SetPosition(pos)
+	entity.Transform.SetScale(scale)
+
+	mat, err := host.MaterialCache().Material(assets.MaterialDefinitionUnlit)
+	if err != nil {
+		fmt.Printf("Warning: could not load material: %v\n", err)
+		return
+	}
+
+	drawing := rendering.Drawing{
+		Material:   mat,
+		Mesh:       mesh,
+		Transform:  &entity.Transform,
+		ViewCuller: &host.Cameras.Primary,
+		ShaderData: &shader_data_registry.ShaderDataUnlit{
+			ShaderDataBase: rendering.NewShaderDataBase(),
+			Color:          color,
+			UVs:            matrix.NewVec4(0, 0, 1, 1),
+		},
+	}
+	host.Drawings.AddDrawing(drawing)
+}
+
+func (g *DoubleslitGame) createLabBench(host *engine.Host) {
+	// Bench top
+	g.createCube(host,
+		matrix.NewVec3(0, 0, 0),
+		matrix.NewVec3(3, 0.15, 22),
+		colBronze())
+
+	// Bench legs
+	for _, z := range []matrix.Float{-9, -3, 3, 9} {
+		for _, x := range []matrix.Float{-1.2, 1.2} {
+			g.createCube(host,
+				matrix.NewVec3(x, -1.0, z),
+				matrix.NewVec3(0.15, 2.0, 0.15),
+				colCopper())
+		}
+	}
+
+	// Floor
+	g.createCube(host,
+		matrix.NewVec3(0, -2.01, 0),
+		matrix.NewVec3(40, 0.02, 40),
+		colMidnight())
+}
+
+func (g *DoubleslitGame) createApparatus(host *engine.Host) {
+	// Source
+	g.createCube(host,
+		matrix.NewVec3(0, 0.5, -10),
+		matrix.NewVec3(0.8, 0.8, 0.8),
+		colBrass())
+
+	// Barrier sections (schematic slit separation)
+	var slitSepNDU matrix.Float = 1.0
+	halfSep := slitSepNDU / 2
+	var slitW matrix.Float = 0.05
+	var barrierH matrix.Float = 3.0
+
+	leftW := 2.5 - halfSep - slitW/2
+	g.createCube(host,
+		matrix.NewVec3(-(halfSep+slitW/2+leftW/2), 0.5+barrierH/2, 0),
+		matrix.NewVec3(leftW, barrierH, 0.1),
+		colSteel())
+
+	centerW := slitSepNDU - slitW
+	g.createCube(host,
+		matrix.NewVec3(0, 0.5+barrierH/2, 0),
+		matrix.NewVec3(centerW, barrierH, 0.1),
+		colSteel())
+
+	g.createCube(host,
+		matrix.NewVec3(halfSep+slitW/2+leftW/2, 0.5+barrierH/2, 0),
+		matrix.NewVec3(leftW, barrierH, 0.1),
+		colSteel())
+
+	// Detector screen
+	g.createCube(host,
+		matrix.NewVec3(0, 0.5+2, 10),
+		matrix.NewVec3(10, 4, 0.05),
+		matrix.NewColor(0.12, 0.12, 0.12, 0.86))
+}
+
+func (g *DoubleslitGame) update(dt matrix.Float) {
+	kb := g.host.Window.Keyboard
+	mouse := g.host.Window.Mouse
+
+	// Quit: ESC or Ctrl+Alt+Esc
+	if kb.KeyDown(hid.KeyboardKeyEscape) {
+		fmt.Println("ESC — quit")
+		os.Exit(0)
+	}
+
+	// Pause toggle
+	if kb.KeyDown(hid.KeyboardKeySpace) {
+		g.paused = !g.paused
+	}
+
+	// Reset
+	if kb.KeyDown(hid.KeyboardKeyR) {
+		g.particles.Reset()
+		// Remove old hit entities
+		for _, e := range g.hitEntities {
+			e.SetActive(false)
+		}
+		g.hitEntities = g.hitEntities[:0]
+	}
+
+	// FPS Camera — compute delta from previous frame position
+	mpos := mouse.ScreenPosition()
+	if g.hasLastM {
+		dx := mpos.X() - g.lastMX
+		dy := mpos.Y() - g.lastMY
+		g.yaw += matrix.Float(dx) * 0.003
+		g.pitch += matrix.Float(dy) * 0.003
+		if g.pitch > 1.4 {
+			g.pitch = 1.4
+		}
+		if g.pitch < -1.4 {
+			g.pitch = -1.4
+		}
+	}
+	g.lastMX = mpos.X()
+	g.lastMY = mpos.Y()
+	g.hasLastM = true
+
+	cam := g.host.PrimaryCamera()
+	pos := cam.Position()
+
+	fwd := matrix.NewVec3(
+		matrix.Float(math.Cos(float64(g.yaw))),
+		0,
+		matrix.Float(math.Sin(float64(g.yaw))),
+	)
+	right := matrix.NewVec3(-fwd.Z(), 0, fwd.X())
+	moveSpeed := g.speed * dt
+
+	if kb.KeyHeld(hid.KeyboardKeyW) {
+		pos = pos.Add(fwd.Scale(moveSpeed))
+	}
+	if kb.KeyHeld(hid.KeyboardKeyS) {
+		pos = pos.Subtract(fwd.Scale(moveSpeed))
+	}
+	if kb.KeyHeld(hid.KeyboardKeyA) {
+		pos = pos.Subtract(right.Scale(moveSpeed))
+	}
+	if kb.KeyHeld(hid.KeyboardKeyD) {
+		pos = pos.Add(right.Scale(moveSpeed))
+	}
+
+	cam.SetPosition(pos)
+	target := pos.Add(matrix.NewVec3(
+		matrix.Float(math.Cos(float64(g.pitch))*math.Cos(float64(g.yaw))),
+		matrix.Float(math.Sin(float64(g.pitch))),
+		matrix.Float(math.Cos(float64(g.pitch))*math.Sin(float64(g.yaw))),
+	))
+	cam.SetLookAt(target)
+
+	// Particle update
+	if !g.paused || dsBenchmarkMode {
+		prevCount := len(g.particles.Hits)
+		g.particles.Update(float32(dt))
+
+		// Spawn hit-dot entities for new particles
+		for i := prevCount; i < len(g.particles.Hits); i++ {
+			h := g.particles.Hits[i]
+			g.spawnHitDot(h)
+		}
+	}
+
+	// Benchmark: track frame times and record checkpoints
+	if dsBenchmarkMode {
+		g.frameTimeAccum += float32(dt)
+		g.frameCount++
+
+		nHits := len(g.particles.Hits)
+		if g.nextCheckpointIdx < len(dsBenchCheckpoints) && nHits >= dsBenchCheckpoints[g.nextCheckpointIdx] {
+			avgFrameTime := g.frameTimeAccum / float32(g.frameCount)
+			avgFPS := float32(1.0) / avgFrameTime
+			cp := dsBenchCheckpoint{
+				Particles:   nHits,
+				FPS:         avgFPS,
+				FrameTimeMs: avgFrameTime * 1000,
+				RSSMb:       dsGetRSSMb(),
+			}
+			g.benchResults = append(g.benchResults, cp)
+			fmt.Printf("  [%d] particles=%d fps=%.1f frame=%.2fms rss=%.1fMB\n",
+				g.nextCheckpointIdx, cp.Particles, cp.FPS, cp.FrameTimeMs, cp.RSSMb)
+			g.nextCheckpointIdx++
+			g.frameTimeAccum = 0
+			g.frameCount = 0
+		}
+
+		// Exit after all checkpoints
+		if g.nextCheckpointIdx >= len(dsBenchCheckpoints) {
+			dsWriteBenchCSV("bench_kaiju.csv", g.benchResults, time.Since(g.benchStart))
+			g.host.Close()
+		}
+	}
+}
+
+func (g *DoubleslitGame) spawnHitDot(h dsScreenHit) {
+	mesh := rendering.NewMeshSphere(g.host.MeshCache(), 0.02, 4, 8)
+	entity := engine.NewEntity(g.host.WorkGroup())
+	entity.Transform.SetPosition(matrix.NewVec3(h.NDUX, 0.5+2.0+h.NDUY, 10-0.03))
+	entity.Transform.SetScale(matrix.NewVec3(1, 1, 1))
+
+	mat, err := g.host.MaterialCache().Material(assets.MaterialDefinitionUnlit)
+	if err != nil {
+		return
+	}
+
+	drawing := rendering.Drawing{
+		Material:   mat,
+		Mesh:       mesh,
+		Transform:  &entity.Transform,
+		ViewCuller: &g.host.Cameras.Primary,
+		ShaderData: &shader_data_registry.ShaderDataUnlit{
+			ShaderDataBase: rendering.NewShaderDataBase(),
+			Color:          colGold(),
+			UVs:            matrix.NewVec4(0, 0, 1, 1),
+		},
+	}
+	g.host.Drawings.AddDrawing(drawing)
+	g.hitEntities = append(g.hitEntities, entity)
+}
+
+func getGame() bootstrap.GameInterface {
+	if labMode {
+		return &LabGame{}
+	}
+	if uiSmokeTestMode {
+		return &UISmokeTestGame{}
+	}
+	return &DoubleslitGame{}
+}

--- a/src/bakeoff/kaiju/game/ds_devices.go
+++ b/src/bakeoff/kaiju/game/ds_devices.go
@@ -1,0 +1,438 @@
+//go:build !editor
+
+// Double-Slit concrete devices implementing the instrument interfaces.
+//
+// Devices:
+//   - DSEmitter:       Movable — controls particle emission rate
+//   - DSSlit:          Movable — adjusts slit separation and width
+//   - DSDetector:      Triggerable — accumulates hits, emits DataEvents
+//   - DSOracle:        Triggerable — loads oracle predictions for V&V
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+)
+
+const dsHistogramBins = 100
+
+// ---------------------------------------------------------------------------
+// DSEmitter — Movable: controls particle emission
+// ---------------------------------------------------------------------------
+
+type DSEmitter struct {
+	name   string
+	status DeviceStatus
+	rate   float64 // particles per second
+}
+
+func NewDSEmitter() *DSEmitter {
+	return &DSEmitter{
+		name:   "emitter",
+		status: StatusIdle,
+		rate:   500,
+	}
+}
+
+func (e *DSEmitter) Name() string         { return e.name }
+func (e *DSEmitter) Status() DeviceStatus { return e.status }
+func (e *DSEmitter) Update(dt float64)    {} // Emitter has no per-frame work
+
+func (e *DSEmitter) Params() []ParamDescriptor {
+	return []ParamDescriptor{
+		{Name: "rate", Min: 10, Max: 5000, Default: 500, Unit: "Hz"},
+	}
+}
+
+func (e *DSEmitter) Set(param string, value float64) error {
+	switch param {
+	case "rate":
+		if value < 10 || value > 5000 {
+			return fmt.Errorf("rate out of range [10, 5000]: %f", value)
+		}
+		e.rate = value
+		return nil
+	default:
+		return fmt.Errorf("unknown param: %s", param)
+	}
+}
+
+func (e *DSEmitter) Get(param string) (float64, error) {
+	switch param {
+	case "rate":
+		return e.rate, nil
+	default:
+		return 0, fmt.Errorf("unknown param: %s", param)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DSSlit — Movable: adjusts slit geometry
+// ---------------------------------------------------------------------------
+
+type DSSlit struct {
+	name       string
+	status     DeviceStatus
+	separation float64 // d in meters
+	width      float64 // a in meters
+}
+
+func NewDSSlit() *DSSlit {
+	p := presets[2] // Tonomura defaults
+	return &DSSlit{
+		name:       "slit",
+		status:     StatusIdle,
+		separation: p.SlitSep,
+		width:      p.SlitWidth,
+	}
+}
+
+func (s *DSSlit) Name() string         { return s.name }
+func (s *DSSlit) Status() DeviceStatus { return s.status }
+func (s *DSSlit) Update(dt float64)    {}
+
+func (s *DSSlit) Params() []ParamDescriptor {
+	return []ParamDescriptor{
+		{Name: "separation", Min: 0.1e-6, Max: 10e-6, Default: 1e-6, LogScale: true, Unit: "m"},
+		{Name: "width", Min: 0.01e-6, Max: 1e-6, Default: 0.1e-6, LogScale: true, Unit: "m"},
+	}
+}
+
+func (s *DSSlit) Set(param string, value float64) error {
+	switch param {
+	case "separation":
+		s.separation = value
+		return nil
+	case "width":
+		s.width = value
+		return nil
+	default:
+		return fmt.Errorf("unknown param: %s", param)
+	}
+}
+
+func (s *DSSlit) Get(param string) (float64, error) {
+	switch param {
+	case "separation":
+		return s.separation, nil
+	case "width":
+		return s.width, nil
+	default:
+		return 0, fmt.Errorf("unknown param: %s", param)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DSDetector — Triggerable: accumulates particle hits
+// ---------------------------------------------------------------------------
+
+type DSDetector struct {
+	name      string
+	status    DeviceStatus
+	physics   *LabPhysicsEngine
+	mapper    *LabCoordMapper
+	eventCh   chan DataEvent
+	rng       *rand.Rand
+	emitTimer float64
+
+	Hits      []HitRecord
+	Histogram [dsHistogramBins]int
+	TotalHits int
+}
+
+func NewDSDetector(physics *LabPhysicsEngine, mapper *LabCoordMapper) *DSDetector {
+	return &DSDetector{
+		name:    "detector",
+		status:  StatusIdle,
+		physics: physics,
+		mapper:  mapper,
+		eventCh: make(chan DataEvent, 256),
+		rng:     rand.New(rand.NewSource(99)),
+		Hits:    make([]HitRecord, 0, 10000),
+	}
+}
+
+func (d *DSDetector) Name() string         { return d.name }
+func (d *DSDetector) Status() DeviceStatus { return d.status }
+
+func (d *DSDetector) Start() error {
+	d.status = StatusRunning
+	return nil
+}
+
+func (d *DSDetector) Stop() error {
+	d.status = StatusIdle
+	return nil
+}
+
+func (d *DSDetector) Subscribe() <-chan DataEvent { return d.eventCh }
+
+// Update accumulates hits when the detector is running.
+// emitRate is passed from the emitter device.
+func (d *DSDetector) Update(dt float64) {
+	// Detector accumulation is driven by UpdateWithRate from the room.
+}
+
+// UpdateWithRate is the room-level driver that feeds the emitter rate.
+func (d *DSDetector) UpdateWithRate(dt float64, emitRate float64) {
+	if d.status != StatusRunning {
+		return
+	}
+
+	d.emitTimer += dt
+	interval := 1.0 / emitRate
+	for d.emitTimer >= interval {
+		d.emitTimer -= interval
+
+		x := d.physics.SampleHitPosition()
+		ndux := d.mapper.PhysToNDU(x)
+		nduy := (d.rng.Float64() - 0.5) * 0.3
+
+		t := (x/d.mapper.PhysHalfWidth + 1) / 2
+		bin := int(t * dsHistogramBins)
+		if bin < 0 {
+			bin = 0
+		}
+		if bin >= dsHistogramBins {
+			bin = dsHistogramBins - 1
+		}
+
+		hit := HitRecord{PhysX: x, NDUX: ndux, NDUY: nduy, Bin: bin}
+		d.Hits = append(d.Hits, hit)
+		d.Histogram[bin]++
+		d.TotalHits++
+
+		// Non-blocking send to event channel
+		select {
+		case d.eventCh <- DataEvent{Source: d.name, Payload: hit}:
+		default:
+		}
+	}
+}
+
+func (d *DSDetector) Reset() {
+	d.Hits = d.Hits[:0]
+	d.Histogram = [dsHistogramBins]int{}
+	d.TotalHits = 0
+	d.emitTimer = 0
+}
+
+// MeasuredVisibility estimates V = (Imax - Imin) / (Imax + Imin) from the histogram.
+// Mirrors: floatVisibility in FloatCompute.lean
+// Returns -1 if insufficient data.
+func (d *DSDetector) MeasuredVisibility() float64 {
+	if d.TotalHits < 1000 {
+		return -1
+	}
+
+	// Find max and min bin values (excluding edge bins which may have boundary effects)
+	maxBin := 0
+	minBin := d.TotalHits
+	for i := 5; i < dsHistogramBins-5; i++ {
+		if d.Histogram[i] > maxBin {
+			maxBin = d.Histogram[i]
+		}
+		if d.Histogram[i] < minBin {
+			minBin = d.Histogram[i]
+		}
+	}
+
+	if maxBin+minBin == 0 {
+		return -1
+	}
+	return QBPVisibility(float64(maxBin), float64(minBin))
+}
+
+// FringeSpacingEstimate computes weighted center-of-mass fringe spacing.
+func (d *DSDetector) FringeSpacingEstimate() float64 {
+	if d.TotalHits < 100 {
+		return 0
+	}
+
+	// Find peaks via simple derivative sign change
+	smoothed := make([]float64, dsHistogramBins)
+	for i := 1; i < dsHistogramBins-1; i++ {
+		smoothed[i] = float64(d.Histogram[i-1]+2*d.Histogram[i]+d.Histogram[i+1]) / 4.0
+	}
+
+	var peaks []int
+	for i := 2; i < dsHistogramBins-2; i++ {
+		if smoothed[i] > smoothed[i-1] && smoothed[i] > smoothed[i+1] && smoothed[i] > 3 {
+			peaks = append(peaks, i)
+		}
+	}
+
+	if len(peaks) < 2 {
+		return 0
+	}
+
+	// Average spacing between adjacent peaks in NDU
+	totalSpacing := 0.0
+	for i := 1; i < len(peaks); i++ {
+		binSpacing := float64(peaks[i] - peaks[i-1])
+		totalSpacing += binSpacing
+	}
+	avgBinSpacing := totalSpacing / float64(len(peaks)-1)
+
+	// Convert bin spacing to physical spacing
+	physRange := 2.0 * d.mapper.PhysHalfWidth
+	physSpacing := avgBinSpacing * physRange / float64(dsHistogramBins)
+	return physSpacing
+}
+
+// ---------------------------------------------------------------------------
+// DSOracle — Triggerable: provides expected predictions for V&V
+// ---------------------------------------------------------------------------
+
+type OraclePrediction struct {
+	Experiment string                 `json:"experiment"`
+	Property   string                 `json:"property"`
+	Value      json.RawMessage        `json:"value"`
+	Params     map[string]interface{} `json:"params"`
+}
+
+type DSOracle struct {
+	name        string
+	status      DeviceStatus
+	eventCh     chan DataEvent
+	Predictions []OraclePrediction
+}
+
+func NewDSOracle() *DSOracle {
+	oracle := &DSOracle{
+		name:    "oracle",
+		status:  StatusIdle,
+		eventCh: make(chan DataEvent, 16),
+	}
+	oracle.loadPredictions()
+	return oracle
+}
+
+func (o *DSOracle) loadPredictions() {
+	// Try multiple paths — binary runs from src/bakeoff/kaiju/ but project root varies
+	paths := []string{
+		"../../../tests/oracle_predictions.json",   // from src/bakeoff/kaiju/
+		"../../tests/oracle_predictions.json",       // from src/bakeoff/kaiju/engine/
+		"tests/oracle_predictions.json",             // from project root
+		"src/bakeoff/kaiju/../../../tests/oracle_predictions.json",
+	}
+	var data []byte
+	var err error
+	for _, p := range paths {
+		data, err = os.ReadFile(p)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		fmt.Printf("Warning: could not load oracle predictions: %v\n", err)
+		return
+	}
+
+	var all []OraclePrediction
+	if err := json.Unmarshal(data, &all); err != nil {
+		fmt.Printf("Warning: could not parse oracle predictions: %v\n", err)
+		return
+	}
+
+	// Filter to experiment 03 only
+	for _, p := range all {
+		if p.Experiment == "03" {
+			o.Predictions = append(o.Predictions, p)
+		}
+	}
+	fmt.Printf("Oracle loaded %d predictions for experiment 03\n", len(o.Predictions))
+}
+
+func (o *DSOracle) Name() string         { return o.name }
+func (o *DSOracle) Status() DeviceStatus { return o.status }
+func (o *DSOracle) Update(dt float64)    {}
+
+func (o *DSOracle) Start() error {
+	o.status = StatusRunning
+	return nil
+}
+
+func (o *DSOracle) Stop() error {
+	o.status = StatusIdle
+	return nil
+}
+
+func (o *DSOracle) Subscribe() <-chan DataEvent { return o.eventCh }
+
+// ExpectedFringeSpacing returns the analytical fringe spacing λL/d.
+func (o *DSOracle) ExpectedFringeSpacing(wavelength, screenDist, slitSep float64) float64 {
+	return wavelength * screenDist / slitSep
+}
+
+// ---------------------------------------------------------------------------
+// V&V Verdict Logic
+// ---------------------------------------------------------------------------
+
+type VVVerdict int
+
+const (
+	VerdictCollecting VVVerdict = iota
+	VerdictPass
+	VerdictFail
+	VerdictUnvalidated
+)
+
+func (v VVVerdict) String() string {
+	switch v {
+	case VerdictCollecting:
+		return "COLLECTING..."
+	case VerdictPass:
+		return "PASS"
+	case VerdictFail:
+		return "FAIL"
+	case VerdictUnvalidated:
+		return "UNVALIDATED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// ComputeVerdict checks accumulated data against oracle predictions.
+// For standard QM presets: validates fringe spacing within 5%.
+// For QBP presets: also validates that visibility matches V = 1-η prediction.
+func ComputeVerdict(detector *DSDetector, oracle *DSOracle, physics *LabPhysicsEngine, presetID string) VVVerdict {
+	if presetID == "" || presetID == "custom" {
+		return VerdictUnvalidated
+	}
+
+	if detector.TotalHits < 1000 {
+		return VerdictCollecting
+	}
+
+	expected := oracle.ExpectedFringeSpacing(physics.Wavelength, physics.ScreenDist, physics.SlitSep)
+	measured := detector.FringeSpacingEstimate()
+
+	if measured == 0 || expected == 0 {
+		return VerdictCollecting
+	}
+
+	// Check 1: Fringe spacing within 5%
+	relError := math.Abs(measured-expected) / expected
+	if relError >= 0.05 {
+		return VerdictFail
+	}
+
+	// Check 2 (QBP presets): Verify visibility matches V = 1-η
+	if physics.U1 > 0 && detector.TotalHits >= 3000 {
+		expectedVis := physics.Visibility()
+		measuredVis := detector.MeasuredVisibility()
+		if measuredVis >= 0 {
+			visError := math.Abs(measuredVis - expectedVis)
+			if visError > 0.15 { // Wider tolerance for visibility (statistical)
+				return VerdictFail
+			}
+		}
+	}
+
+	return VerdictPass
+}

--- a/src/bakeoff/kaiju/game/ds_room.go
+++ b/src/bakeoff/kaiju/game/ds_room.go
@@ -50,7 +50,7 @@ type DSRoom struct {
 	// Desk Controls (physical buttons on desk surface)
 	deskControls *DeskControlManager
 
-	// Monitor Text (screen-space UI panels)
+	// Monitor Text (CPU-rasterized text on monitor surfaces)
 	monitorText *MonitorTextSystem
 
 	// Monitors (3D histogram bars on desk screens)
@@ -218,8 +218,8 @@ func (r *DSRoom) Setup(host *engine.Host) {
 		},
 	})
 
-	// Build monitor text (screen-space UI panels)
-	r.monitorText = NewMonitorTextSystem(&r.uiMgr, host)
+	// Build monitor text (CPU-rasterized text on monitor surfaces)
+	r.monitorText = NewMonitorTextSystem(host)
 
 	// Build minimal HUD (crosshair + toggleable help strip)
 	r.buildMinimalHUD(host)

--- a/src/bakeoff/kaiju/game/ds_room.go
+++ b/src/bakeoff/kaiju/game/ds_room.go
@@ -1,0 +1,600 @@
+//go:build !editor
+
+// Double-Slit Experiment Room (Room 03)
+//
+// Wires: DSEmitter + DSSlit + DSDetector + DSOracle
+// Manages: physics engine, coordinate mapper, particle rendering, UI, V&V
+
+package main
+
+import (
+	"fmt"
+	"kaiju/engine"
+	"kaiju/engine/assets"
+	"kaiju/engine/ui"
+	"kaiju/matrix"
+	"kaiju/platform/hid"
+	"kaiju/registry/shader_data_registry"
+	"kaiju/rendering"
+	"os"
+)
+
+type DSRoom struct {
+	host *engine.Host
+
+	// Devices
+	emitter  *DSEmitter
+	slit     *DSSlit
+	detector *DSDetector
+	oracle   *DSOracle
+
+	// Physics
+	physics *LabPhysicsEngine
+	mapper  *LabCoordMapper
+
+	// State
+	running    bool   // Emitter on/off (Enter toggles)
+	timeFrozen bool   // Freeze simulation (Space toggles) — camera still works
+	presetID   string
+	simTime    float64
+
+	// Rendering (cached for perf — Carmack: don't allocate per particle)
+	hitEntities []*engine.Entity
+	hitMesh     *rendering.Mesh
+	hitMat      *rendering.Material
+
+	// Desk Controls (physical buttons on desk surface)
+	deskControls *DeskControlManager
+
+	// Monitor Text (3D SDF text on monitor surfaces)
+	monitorText *MonitorTextSystem
+
+	// Monitors (3D histogram bars on desk screens)
+	monitors *MonitorContent
+
+	// Minimal HUD (crosshair + toggleable help strip)
+	uiMgr        ui.Manager
+	crosshairH   *ui.Panel // Horizontal crosshair bar
+	crosshairV   *ui.Panel // Vertical crosshair bar
+	helpPanel    *ui.Panel
+	helpVisible  bool
+
+	// Audio (scientist "hear" dimension)
+	labAudio     *LabAudio
+	prevHitCount int
+
+	// Oracle overlay
+	showOracle     bool
+	oracleEntities []*engine.Entity
+}
+
+func NewDSRoom() *DSRoom {
+	return &DSRoom{
+		presetID: "tonomura_1989",
+	}
+}
+
+func (r *DSRoom) ID() string          { return "03" }
+func (r *DSRoom) DisplayName() string { return "Experiment 03: Double-Slit" }
+
+func (r *DSRoom) Devices() []Device {
+	return []Device{r.emitter, r.slit, r.detector, r.oracle}
+}
+
+func (r *DSRoom) Setup(host *engine.Host) {
+	r.host = host
+
+	// Physics
+	r.physics = NewLabPhysicsEngine()
+	r.physics.ApplyPreset(r.presetID)
+	r.mapper = NewLabCoordMapper(r.physics.FringeSpacing())
+
+	// Devices
+	r.emitter = NewDSEmitter()
+	r.slit = NewDSSlit()
+	r.slit.separation = r.physics.SlitSep
+	r.slit.width = r.physics.SlitWidth
+	r.detector = NewDSDetector(r.physics, r.mapper)
+	r.oracle = NewDSOracle()
+
+	// Start in running state
+	r.running = true
+	r.emitter.status = StatusRunning
+	r.detector.Start()
+	r.oracle.Start()
+
+	// Cache hit dot mesh and material (one allocation, shared across all particles)
+	r.hitMesh = rendering.NewMeshSphere(host.MeshCache(), 0.015, 4, 8)
+	hitMat, _ := host.MaterialCache().Material(assets.MaterialDefinitionUnlit)
+	r.hitMat = hitMat
+
+	// Build monitor content (3D histogram bars on desk screens)
+	r.monitors = NewMonitorContent(host)
+
+	// Initialize audio feedback
+	r.labAudio = NewLabAudio(host)
+
+	// Build desk controls (physical buttons on desk surface)
+	r.deskControls = NewDeskControlManager(host)
+	r.deskControls.SetupLabControls(LabControlCallbacks{
+		OnStartStop: func() {
+			r.running = !r.running
+			if r.running {
+				r.emitter.status = StatusRunning
+				r.detector.Start()
+			} else {
+				r.emitter.status = StatusIdle
+				r.detector.Stop()
+			}
+			if r.labAudio != nil {
+				r.labAudio.OnButtonClick()
+			}
+		},
+		OnRateUp: func() {
+			newRate := r.emitter.rate * 10
+			if newRate > 50000 {
+				newRate = 50000
+			}
+			r.emitter.rate = newRate
+			fmt.Fprintf(os.Stderr, "Emitter rate: %.0f Hz\n", newRate)
+			if r.labAudio != nil {
+				r.labAudio.OnButtonClick()
+			}
+		},
+		OnRateDown: func() {
+			newRate := r.emitter.rate / 10
+			if newRate < 10 {
+				newRate = 10
+			}
+			r.emitter.rate = newRate
+			fmt.Fprintf(os.Stderr, "Emitter rate: %.0f Hz\n", newRate)
+			if r.labAudio != nil {
+				r.labAudio.OnButtonClick()
+			}
+		},
+		OnReset: func() {
+			r.detector.Reset()
+			for _, e := range r.hitEntities {
+				e.SetActive(false)
+			}
+			r.hitEntities = r.hitEntities[:0]
+			if r.labAudio != nil {
+				r.labAudio.OnButtonClick()
+			}
+		},
+		OnOracleToggle: func() {
+			r.toggleOracleOverlay()
+			if r.labAudio != nil {
+				r.labAudio.OnButtonClick()
+			}
+		},
+		OnPreset: func(id string) {
+			r.applyPreset(id)
+			if r.labAudio != nil {
+				r.labAudio.OnButtonClick()
+			}
+		},
+		OnSlitDial: func(delta float32) {
+			// Adjust slit separation by scroll delta
+			factor := 1.0 + float64(delta)*0.1
+			newSep := r.physics.SlitSep * factor
+			if newSep < 0.1e-6 {
+				newSep = 0.1e-6
+			}
+			if newSep > 10e-6 {
+				newSep = 10e-6
+			}
+			r.physics.SlitSep = newSep
+			r.slit.separation = newSep
+			r.mapper.Update(r.physics.FringeSpacing())
+			r.presetID = "custom"
+			r.detector.Reset()
+			for _, e := range r.hitEntities {
+				e.SetActive(false)
+			}
+			r.hitEntities = r.hitEntities[:0]
+			r.rebuildOracleOverlay()
+		},
+	})
+
+	// Build monitor text (3D SDF text on monitor surfaces)
+	r.monitorText = NewMonitorTextSystem(host)
+
+	// Build minimal HUD (crosshair + toggleable help strip)
+	r.buildMinimalHUD(host)
+
+	// Build oracle overlay geometry (hidden initially)
+	r.buildOracleOverlay(host)
+}
+
+func (r *DSRoom) Update(dt float64) {
+	r.simTime += dt
+
+	if r.running && !r.timeFrozen {
+		// Drive detector with emitter rate
+		r.detector.UpdateWithRate(dt, r.emitter.rate)
+
+		// Spawn new hit dot entities
+		startIdx := len(r.hitEntities)
+		newHits := len(r.detector.Hits) - startIdx
+		for i := startIdx; i < len(r.detector.Hits); i++ {
+			r.spawnHitDot(r.detector.Hits[i])
+		}
+
+		// Audio: particle click (rate-limited Geiger counter)
+		if r.labAudio != nil {
+			r.labAudio.OnParticleHit(dt, newHits)
+		}
+	}
+
+	// Update monitor content (3D histogram bars)
+	verdict := ComputeVerdict(r.detector, r.oracle, r.physics, r.presetID)
+	if r.monitors != nil {
+		r.monitors.UpdateHistogram(r.detector.Histogram)
+	}
+
+	// Audio: verdict change
+	if r.labAudio != nil {
+		r.labAudio.OnVerdictChange(verdict)
+	}
+
+	// Desk controls: raycast + hover + click
+	prevAimed := r.deskControls.aimed
+	aimed := r.deskControls.Update(r.host)
+	if aimed != prevAimed && aimed != nil && r.labAudio != nil {
+		r.labAudio.OnHover()
+	}
+
+	// Update crosshair color (gold when aiming at a control)
+	if aimed != nil {
+		if r.crosshairH != nil {
+			r.crosshairH.SetColor(labColGold())
+		}
+		if r.crosshairV != nil {
+			r.crosshairV.SetColor(labColGold())
+		}
+	} else {
+		if r.crosshairH != nil {
+			r.crosshairH.SetColor(labColIvory())
+		}
+		if r.crosshairV != nil {
+			r.crosshairV.SetColor(labColIvory())
+		}
+	}
+
+	// Update monitor text (3D SDF text on monitor surfaces)
+	r.updateMonitorText(verdict)
+}
+
+func (r *DSRoom) Teardown() {
+	// Cleanup if needed
+}
+
+// ---------------------------------------------------------------------------
+// Particle Rendering — Gold spheres on detector
+// ---------------------------------------------------------------------------
+
+func (r *DSRoom) spawnHitDot(hit HitRecord) {
+	entity := engine.NewEntity(r.host.WorkGroup())
+
+	// Place hit on detector screen face (YZ plane at screenX)
+	appY := matrix.Float(benchY + benchThick/2)
+	screenX := matrix.Float(benchLen/2 - 0.5)
+	screenH := matrix.Float(0.6)
+	x := screenX - 0.015 // Slightly in front of screen
+	y := appY + screenH/2 + matrix.Float(hit.NDUY)*0.3
+	z := matrix.Float(benchZ) + matrix.Float(hit.NDUX)*0.08 // Scale NDU to bench Z range
+
+	entity.Transform.SetPosition(matrix.NewVec3(x, y, z))
+	entity.Transform.SetScale(matrix.NewVec3(1, 1, 1))
+
+	drawing := rendering.Drawing{
+		Material:  r.hitMat,
+		Mesh:      r.hitMesh,
+		Transform: &entity.Transform,
+		ShaderData: &shader_data_registry.ShaderDataUnlit{
+			ShaderDataBase: rendering.NewShaderDataBase(),
+			Color:          labColGold(),
+			UVs:            matrix.NewVec4(0, 0, 1, 1),
+		},
+		ViewCuller: &r.host.Cameras.Primary,
+	}
+	r.host.Drawings.AddDrawing(drawing)
+	r.hitEntities = append(r.hitEntities, entity)
+}
+
+// ---------------------------------------------------------------------------
+// Oracle Overlay — Fraunhofer curve projected onto detector
+// ---------------------------------------------------------------------------
+
+func (r *DSRoom) buildOracleOverlay(host *engine.Host) {
+	steps := 100
+	appY := matrix.Float(benchY + benchThick/2)
+	screenX := matrix.Float(benchLen/2 - 0.5)
+	screenH := matrix.Float(0.6)
+
+	for i := 0; i < steps; i++ {
+		t := float64(i)/float64(steps)*2 - 1
+		x := t * r.mapper.PhysHalfWidth
+		intensity := r.physics.Intensity(x)
+
+		mesh := rendering.NewMeshSphere(host.MeshCache(), 0.008, 3, 6)
+		entity := engine.NewEntity(host.WorkGroup())
+
+		px := screenX - 0.03 // In front of detector, with depth bias
+		py := appY + screenH*matrix.Float(0.1+intensity*0.8)
+		pz := matrix.Float(benchZ) + matrix.Float(r.mapper.PhysToNDU(x))*0.08
+
+		entity.Transform.SetPosition(matrix.NewVec3(px, py, pz))
+		entity.Transform.SetScale(matrix.NewVec3(1, 1, 1))
+		entity.SetActive(false) // Hidden initially
+
+		mat, err := host.MaterialCache().Material(assets.MaterialDefinitionUnlit)
+		if err != nil {
+			continue
+		}
+
+		drawing := rendering.Drawing{
+			Material:  mat,
+			Mesh:      mesh,
+			Transform: &entity.Transform,
+			ShaderData: &shader_data_registry.ShaderDataUnlit{
+				ShaderDataBase: rendering.NewShaderDataBase(),
+				Color:          labColAmber(),
+				UVs:            matrix.NewVec4(0, 0, 1, 1),
+			},
+			ViewCuller: &host.Cameras.Primary,
+		}
+		host.Drawings.AddDrawing(drawing)
+		r.oracleEntities = append(r.oracleEntities, entity)
+	}
+}
+
+func (r *DSRoom) toggleOracleOverlay() {
+	r.showOracle = !r.showOracle
+	for _, e := range r.oracleEntities {
+		e.SetActive(r.showOracle)
+	}
+}
+
+func (r *DSRoom) rebuildOracleOverlay() {
+	// Update oracle overlay positions when physics params change
+	steps := len(r.oracleEntities)
+	appY := matrix.Float(benchY + benchThick/2)
+	screenX := matrix.Float(benchLen/2 - 0.5)
+	screenH := matrix.Float(0.6)
+
+	for i, entity := range r.oracleEntities {
+		t := float64(i)/float64(steps)*2 - 1
+		x := t * r.mapper.PhysHalfWidth
+		intensity := r.physics.Intensity(x)
+
+		px := screenX - 0.03
+		py := appY + screenH*matrix.Float(0.1+intensity*0.8)
+		pz := matrix.Float(benchZ) + matrix.Float(r.mapper.PhysToNDU(x))*0.08
+
+		entity.Transform.SetPosition(matrix.NewVec3(px, py, pz))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Minimal HUD — Crosshair + Toggleable Help Strip
+// ---------------------------------------------------------------------------
+
+func (r *DSRoom) buildMinimalHUD(host *engine.Host) {
+	r.uiMgr.Init(host)
+
+	tex, err := host.TextureCache().Texture(
+		assets.TextureSquare, rendering.TextureFilterLinear)
+	if err != nil {
+		fmt.Printf("Warning: could not load square texture: %v\n", err)
+		return
+	}
+
+	// ── Crosshair (tiny + at screen center) ──
+	w, h := host.Window.Width(), host.Window.Height()
+	cx, cy := float32(w)/2, float32(h)/2
+
+	// Horizontal bar
+	r.crosshairH = r.uiMgr.Add().ToPanel()
+	r.crosshairH.Init(tex, ui.ElementTypePanel)
+	r.crosshairH.DontFitContent()
+	r.crosshairH.SetColor(labColIvory())
+	r.crosshairH.Base().Layout().SetPositioning(ui.PositioningAbsolute)
+	r.crosshairH.Base().Layout().Scale(12, 2)
+	r.crosshairH.Base().Layout().SetOffset(cx-6, cy-1)
+
+	// Vertical bar
+	r.crosshairV = r.uiMgr.Add().ToPanel()
+	r.crosshairV.Init(tex, ui.ElementTypePanel)
+	r.crosshairV.DontFitContent()
+	r.crosshairV.SetColor(labColIvory())
+	r.crosshairV.Base().Layout().SetPositioning(ui.PositioningAbsolute)
+	r.crosshairV.Base().Layout().Scale(2, 12)
+	r.crosshairV.Base().Layout().SetOffset(cx-1, cy-6)
+
+	// ── Help Strip (toggleable with H key, starts hidden) ──
+	r.helpPanel = r.uiMgr.Add().ToPanel()
+	r.helpPanel.Init(tex, ui.ElementTypePanel)
+	r.helpPanel.DontFitContent()
+	r.helpPanel.AllowClickThrough()
+	r.helpPanel.SetColor(matrix.NewColor(0, 0, 0, 0.6))
+	r.helpPanel.Base().Layout().SetPositioning(ui.PositioningAbsolute)
+	r.helpPanel.Base().Layout().Scale(750, 25)
+	r.helpPanel.Base().Layout().SetOffset(float32(w)/2-375, float32(h)-30)
+	r.helpPanel.Base().Layout().SetPadding(10, 4, 10, 4)
+
+	helpLabel := r.uiMgr.Add().ToLabel()
+	helpLabel.Init("H:HUD | Enter:emitter | Space:freeze | +/-:rate | 5-9:presets | O:oracle | R:reset | Q:sit")
+	helpLabel.SetColor(labColSteel())
+	helpLabel.SetBGColor(matrix.NewColor(0, 0, 0, 0))
+	helpLabel.SetFontSize(12)
+	r.helpPanel.AddChild(helpLabel.Base())
+
+	// Start hidden
+	r.helpVisible = false
+	r.helpPanel.Base().Entity().SetActive(false)
+}
+
+func (r *DSRoom) updateMonitorText(verdict VVVerdict) {
+	if r.monitorText == nil {
+		return
+	}
+
+	// Left-Top: Experiment title + physics mode
+	modeStr := "Standard QM"
+	if r.physics.U1 > 0 {
+		modeStr = fmt.Sprintf("QBP (U1=%.0e)", r.physics.U1)
+	}
+	title := fmt.Sprintf("Exp 03: Double-Slit\n%s", modeStr)
+
+	// Left-Bottom: V&V verdict + QBP values
+	eta := r.physics.Eta()
+	vis := r.physics.Visibility()
+	verdictStr := fmt.Sprintf("VERDICT: %s\neta=%.3f V=%.3f", verdict, eta, vis)
+
+	// Right-Top: Stats (particle count, fringe)
+	expected := r.oracle.ExpectedFringeSpacing(r.physics.Wavelength, r.physics.ScreenDist, r.physics.SlitSep)
+	measured := r.detector.FringeSpacingEstimate()
+	measuredStr := "--"
+	if measured > 0 {
+		measuredStr = fmt.Sprintf("%.1f um", measured*1e6)
+	}
+	statsStr := fmt.Sprintf("N = %d\nFringe: %s / %.1f um", r.detector.TotalHits, measuredStr, expected*1e6)
+
+	// Right-Bottom: Preset + rate info
+	statusStr := "RUNNING"
+	if r.timeFrozen {
+		statusStr = "FROZEN"
+	} else if !r.running {
+		statusStr = "STOPPED"
+	}
+	infoStr := fmt.Sprintf("Preset: %s\nRate: %d Hz  [%s]", r.presetID, int(r.emitter.rate), statusStr)
+
+	r.monitorText.UpdateAll(title, verdictStr, statsStr, infoStr)
+	r.monitorText.Flush()
+}
+
+// HandleInput processes experiment-specific keyboard input.
+// Returns true if the input was consumed.
+func (r *DSRoom) HandleInput(host *engine.Host) bool {
+	kb := host.Window.Keyboard
+
+	// H: toggle help strip
+	if kb.KeyDown(hid.KeyboardKeyH) {
+		r.helpVisible = !r.helpVisible
+		if r.helpPanel != nil {
+			r.helpPanel.Base().Entity().SetActive(r.helpVisible)
+		}
+		return true
+	}
+
+	// Enter: toggle emitter start/stop
+	if kb.KeyDown(hid.KeyboardKeyEnter) {
+		r.running = !r.running
+		if r.running {
+			r.emitter.status = StatusRunning
+			r.detector.Start()
+		} else {
+			r.emitter.status = StatusIdle
+			r.detector.Stop()
+		}
+		return true
+	}
+
+	// Space: freeze/unfreeze time (simulation pauses, camera still moves)
+	if kb.KeyDown(hid.KeyboardKeySpace) {
+		r.timeFrozen = !r.timeFrozen
+		return true
+	}
+
+	// O: toggle oracle overlay
+	if kb.KeyDown(hid.KeyboardKeyO) {
+		r.toggleOracleOverlay()
+		return true
+	}
+
+	// R: reset detector
+	if kb.KeyDown(hid.KeyboardKeyR) {
+		r.detector.Reset()
+		for _, e := range r.hitEntities {
+			e.SetActive(false)
+		}
+		r.hitEntities = r.hitEntities[:0]
+		return true
+	}
+
+	// 5: Bach preset
+	if kb.KeyDown(hid.KeyboardKey5) {
+		r.applyPreset("bach_2013")
+		return true
+	}
+
+	// 6: Zeilinger preset
+	if kb.KeyDown(hid.KeyboardKey6) {
+		r.applyPreset("zeilinger_1988")
+		return true
+	}
+
+	// 7: Tonomura preset
+	if kb.KeyDown(hid.KeyboardKey7) {
+		r.applyPreset("tonomura_1989")
+		return true
+	}
+
+	// 8: QBP weak coupling
+	if kb.KeyDown(hid.KeyboardKey8) {
+		r.applyPreset("qbp_weak")
+		return true
+	}
+
+	// 9: QBP strong coupling
+	if kb.KeyDown(hid.KeyboardKey9) {
+		r.applyPreset("qbp_strong")
+		return true
+	}
+
+	// +/=: emitter rate ×10
+	if kb.KeyDown(hid.KeyboardKeyEqual) || kb.KeyDown(hid.KeyboardNumKeyAdd) {
+		newRate := r.emitter.rate * 10
+		if newRate > 50000 {
+			newRate = 50000
+		}
+		r.emitter.rate = newRate
+		fmt.Fprintf(os.Stderr, "Emitter rate: %.0f Hz\n", newRate)
+		return true
+	}
+
+	// -: emitter rate ÷10
+	if kb.KeyDown(hid.KeyboardKeyMinus) || kb.KeyDown(hid.KeyboardNumKeySubtract) {
+		newRate := r.emitter.rate / 10
+		if newRate < 10 {
+			newRate = 10
+		}
+		r.emitter.rate = newRate
+		fmt.Fprintf(os.Stderr, "Emitter rate: %.0f Hz\n", newRate)
+		return true
+	}
+
+	return false
+}
+
+func (r *DSRoom) applyPreset(id string) {
+	if !r.physics.ApplyPreset(id) {
+		return
+	}
+	r.presetID = id
+	r.slit.separation = r.physics.SlitSep
+	r.slit.width = r.physics.SlitWidth
+	r.mapper.Update(r.physics.FringeSpacing())
+
+	// Reset detector
+	r.detector.Reset()
+	for _, e := range r.hitEntities {
+		e.SetActive(false)
+	}
+	r.hitEntities = r.hitEntities[:0]
+
+	// Rebuild oracle overlay
+	r.rebuildOracleOverlay()
+}

--- a/src/bakeoff/kaiju/game/instrument.go
+++ b/src/bakeoff/kaiju/game/instrument.go
@@ -1,0 +1,85 @@
+//go:build !editor
+
+// Instrument Abstraction Layer for QBP Virtual Lab
+//
+// Inspired by Bluesky/ophyd (Device, Readable, Movable) and TANGO Controls
+// (commands, attributes, properties). Adapted for a Go game loop where
+// Update() is called every frame.
+//
+// Three core interfaces:
+//   - Device:      base — has a name, status, per-frame update
+//   - Movable:     writable parameters (sliders, knobs)
+//   - Triggerable: start/stop with event stream output (detectors, oracles)
+
+package main
+
+// DeviceStatus represents the operational state of a lab device.
+type DeviceStatus int
+
+const (
+	StatusIdle    DeviceStatus = iota // Device is idle
+	StatusRunning                     // Device is actively producing/measuring
+	StatusError                       // Device encountered an error
+)
+
+func (s DeviceStatus) String() string {
+	switch s {
+	case StatusIdle:
+		return "IDLE"
+	case StatusRunning:
+		return "RUNNING"
+	case StatusError:
+		return "ERROR"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// DataEvent is an event emitted by a Triggerable device.
+// Payload is intentionally untyped — consumers assert to the expected type.
+type DataEvent struct {
+	Timestamp float64 // Simulation time (seconds since room start)
+	Source    string  // Device name that emitted this event
+	Payload  any     // float64, []float64, HitRecord, etc.
+}
+
+// HitRecord is the payload for a single particle detection event.
+type HitRecord struct {
+	PhysX float64 // Physical position in meters
+	NDUX  float64 // Normalized display unit X
+	NDUY  float64 // Normalized display unit Y (small spread)
+	Bin   int     // Histogram bin index
+}
+
+// ParamDescriptor describes a single adjustable parameter on a Movable device.
+type ParamDescriptor struct {
+	Name     string
+	Min, Max float64
+	Default  float64
+	LogScale bool
+	Unit     string
+}
+
+// Device is the base interface for all lab instruments.
+type Device interface {
+	Name() string
+	Status() DeviceStatus
+	Update(dt float64) // Called every frame by the room's update loop
+}
+
+// Movable is a device with adjustable parameters (e.g., slit width, emitter rate).
+type Movable interface {
+	Device
+	Set(param string, value float64) error
+	Get(param string) (float64, error)
+	Params() []ParamDescriptor
+}
+
+// Triggerable is a device that can be started/stopped and produces a stream
+// of DataEvents (e.g., a detector accumulating hits, an oracle emitting predictions).
+type Triggerable interface {
+	Device
+	Start() error
+	Stop() error
+	Subscribe() <-chan DataEvent
+}

--- a/src/bakeoff/kaiju/game/lab_audio.go
+++ b/src/bakeoff/kaiju/game/lab_audio.go
@@ -1,0 +1,202 @@
+//go:build !editor
+
+// Audio feedback for the QBP Virtual Lab.
+//
+// Implements the "Hear" dimension of the scientist UX:
+//   - Particle click: short tick on each detector hit (rate-limited)
+//   - Verdict ding: pleasant tone when V&V passes
+//   - Verdict buzz: low tone when V&V fails
+//
+// Sounds are generated procedurally as WAV data — no external audio files needed.
+// Uses Kaiju's SoLoud audio backend via host.Audio().
+
+package main
+
+import (
+	"encoding/binary"
+	"kaiju/engine"
+	"kaiju/platform/audio"
+	"math"
+)
+
+type LabAudio struct {
+	host *engine.Host
+
+	clickClip    *audio.AudioClip
+	dingClip     *audio.AudioClip
+	buzzClip     *audio.AudioClip
+	hoverClip    *audio.AudioClip  // Subtle hover tick
+	buttonClip   *audio.AudioClip  // Satisfying button click
+
+	// Rate limiter for particle clicks (avoid 500 clicks/sec)
+	clickBudget float64 // Accumulated time budget
+	clickRate   float64 // Max clicks per second
+	lastVerdict VVVerdict
+}
+
+func NewLabAudio(host *engine.Host) *LabAudio {
+	la := &LabAudio{
+		host:        host,
+		clickRate:   15, // 15 clicks/sec max (Geiger counter feel)
+		lastVerdict: VerdictCollecting,
+	}
+	la.generateSounds()
+	return la
+}
+
+// OnParticleHit should be called each frame with the number of new hits.
+// Rate-limits audio to avoid overwhelming the sound system.
+func (la *LabAudio) OnParticleHit(dt float64, newHits int) {
+	if la.clickClip == nil || newHits == 0 {
+		return
+	}
+
+	la.clickBudget += dt * la.clickRate
+	if la.clickBudget > 3 {
+		la.clickBudget = 3 // Cap burst
+	}
+
+	if la.clickBudget >= 1 {
+		la.host.Audio().Play(la.clickClip)
+		la.clickBudget -= 1
+	}
+}
+
+// OnVerdictChange plays a sound when the verdict changes.
+func (la *LabAudio) OnVerdictChange(verdict VVVerdict) {
+	if verdict == la.lastVerdict {
+		return
+	}
+	la.lastVerdict = verdict
+
+	switch verdict {
+	case VerdictPass:
+		if la.dingClip != nil {
+			la.host.Audio().Play(la.dingClip)
+		}
+	case VerdictFail:
+		if la.buzzClip != nil {
+			la.host.Audio().Play(la.buzzClip)
+		}
+	}
+}
+
+// OnHover plays a subtle tick when the crosshair enters a new control.
+func (la *LabAudio) OnHover() {
+	if la.hoverClip != nil {
+		la.host.Audio().Play(la.hoverClip)
+	}
+}
+
+// OnButtonClick plays a satisfying mechanical click when a desk control is pressed.
+func (la *LabAudio) OnButtonClick() {
+	if la.buttonClip != nil {
+		la.host.Audio().Play(la.buttonClip)
+	}
+}
+
+func (la *LabAudio) generateSounds() {
+	adb := la.host.AssetDatabase()
+	a := la.host.Audio()
+
+	// Click: 15ms white-noise burst with exponential decay
+	clickWav := generateClick(44100, 0.015)
+	adb.Cache("lab_click.wav", clickWav)
+	la.clickClip, _ = a.LoadSound(adb, "lab_click.wav")
+
+	// Ding: 200ms sine at 880Hz with decay (pleasant A5)
+	dingWav := generateTone(44100, 0.2, 880, 0.4)
+	adb.Cache("lab_ding.wav", dingWav)
+	la.dingClip, _ = a.LoadSound(adb, "lab_ding.wav")
+
+	// Buzz: 200ms sawtooth at 220Hz (low warning A3)
+	buzzWav := generateBuzz(44100, 0.2, 220, 0.3)
+	adb.Cache("lab_buzz.wav", buzzWav)
+	la.buzzClip, _ = a.LoadSound(adb, "lab_buzz.wav")
+
+	// Hover tick: 5ms very quiet click (subtle feedback)
+	hoverWav := generateClick(44100, 0.005)
+	adb.Cache("lab_hover.wav", hoverWav)
+	la.hoverClip, _ = a.LoadSound(adb, "lab_hover.wav")
+
+	// Button click: 30ms mid-frequency snap (satisfying mechanical feel)
+	buttonWav := generateTone(44100, 0.03, 1200, 0.5)
+	adb.Cache("lab_button.wav", buttonWav)
+	la.buttonClip, _ = a.LoadSound(adb, "lab_button.wav")
+}
+
+// ---------------------------------------------------------------------------
+// Procedural WAV generators
+// ---------------------------------------------------------------------------
+
+// generateClick creates a short noise burst with exponential decay.
+func generateClick(sampleRate int, duration float64) []byte {
+	numSamples := int(float64(sampleRate) * duration)
+	samples := make([]int16, numSamples)
+
+	// Simple LCG for deterministic noise (no rand dependency)
+	seed := uint32(0xDEADBEEF)
+	for i := range samples {
+		seed = seed*1664525 + 1013904223
+		noise := float64(int32(seed)) / float64(math.MaxInt32)
+		decay := math.Exp(-float64(i) / float64(numSamples) * 6)
+		samples[i] = int16(noise * decay * 16000)
+	}
+	return encodeWAV(samples, sampleRate)
+}
+
+// generateTone creates a sine wave with exponential decay.
+func generateTone(sampleRate int, duration, freq, volume float64) []byte {
+	numSamples := int(float64(sampleRate) * duration)
+	samples := make([]int16, numSamples)
+
+	for i := range samples {
+		t := float64(i) / float64(sampleRate)
+		decay := math.Exp(-t / duration * 4)
+		val := math.Sin(2*math.Pi*freq*t) * decay * volume
+		samples[i] = int16(val * 32000)
+	}
+	return encodeWAV(samples, sampleRate)
+}
+
+// generateBuzz creates a sawtooth wave with slight decay (warning tone).
+func generateBuzz(sampleRate int, duration, freq, volume float64) []byte {
+	numSamples := int(float64(sampleRate) * duration)
+	samples := make([]int16, numSamples)
+
+	period := float64(sampleRate) / freq
+	for i := range samples {
+		t := float64(i) / float64(sampleRate)
+		decay := math.Exp(-t / duration * 2)
+		phase := math.Mod(float64(i), period) / period
+		saw := 2*phase - 1
+		samples[i] = int16(saw * decay * volume * 32000)
+	}
+	return encodeWAV(samples, sampleRate)
+}
+
+// encodeWAV wraps 16-bit mono PCM samples in a WAV header.
+func encodeWAV(samples []int16, sampleRate int) []byte {
+	dataSize := len(samples) * 2
+	fileSize := 44 + dataSize
+
+	buf := make([]byte, fileSize)
+	copy(buf[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(fileSize-8))
+	copy(buf[8:12], "WAVE")
+	copy(buf[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(buf[16:20], 16) // Chunk size
+	binary.LittleEndian.PutUint16(buf[20:22], 1)  // PCM
+	binary.LittleEndian.PutUint16(buf[22:24], 1)  // Mono
+	binary.LittleEndian.PutUint32(buf[24:28], uint32(sampleRate))
+	binary.LittleEndian.PutUint32(buf[28:32], uint32(sampleRate*2)) // Byte rate
+	binary.LittleEndian.PutUint16(buf[32:34], 2)                    // Block align
+	binary.LittleEndian.PutUint16(buf[34:36], 16)                   // Bits per sample
+	copy(buf[36:40], "data")
+	binary.LittleEndian.PutUint32(buf[40:44], uint32(dataSize))
+
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(buf[44+i*2:46+i*2], uint16(s))
+	}
+	return buf
+}

--- a/src/bakeoff/kaiju/game/lab_game.go
+++ b/src/bakeoff/kaiju/game/lab_game.go
@@ -1,0 +1,761 @@
+//go:build !editor
+
+// QBP Phase 4e — Double-Slit Lab
+//
+// Interactive 3D lab room for Experiment 03 verification & validation.
+// Run with: QBP_LAB=1 ./doubleslit
+// (Default still runs the bake-off prototype.)
+
+package main
+
+import (
+	"fmt"
+	"kaiju/engine"
+	"kaiju/engine/assets"
+	"kaiju/matrix"
+	"kaiju/platform/hid"
+	"kaiju/registry/shader_data_registry"
+	"kaiju/rendering"
+	"math"
+	"math/rand"
+	"os"
+	"os/signal"
+	"reflect"
+	"syscall"
+	"time"
+)
+
+var labMode = os.Getenv("QBP_LAB") == "1"
+
+// ---------------------------------------------------------------------------
+// Design System Colors (from docs/design-system.md)
+// ---------------------------------------------------------------------------
+
+func labColVerdantNight() matrix.Color { return matrix.NewColor(13.0/255, 40.0/255, 32.0/255, 1) }
+func labColMidnight() matrix.Color     { return matrix.NewColor(13.0/255, 27.0/255, 42.0/255, 1) }
+func labColBrass() matrix.Color        { return matrix.NewColor(212.0/255, 165.0/255, 116.0/255, 1) }
+func labColCopper() matrix.Color       { return matrix.NewColor(184.0/255, 115.0/255, 51.0/255, 1) }
+func labColBronze() matrix.Color       { return matrix.NewColor(205.0/255, 127.0/255, 50.0/255, 1) }
+func labColSteel() matrix.Color        { return matrix.NewColor(113.0/255, 121.0/255, 126.0/255, 1) }
+func labColOchre() matrix.Color        { return matrix.NewColor(212.0/255, 170.0/255, 90.0/255, 1) }
+func labColAmber() matrix.Color        { return matrix.NewColor(244.0/255, 162.0/255, 97.0/255, 1) }
+func labColGold() matrix.Color         { return matrix.NewColor(1, 215.0/255, 0, 1) }
+func labColIvory() matrix.Color        { return matrix.NewColor(1, 254.0/255, 240.0/255, 1) }
+func labColFloor() matrix.Color        { return matrix.NewColor(10.0/255, 20.0/255, 30.0/255, 1) }
+
+// Suppress unused
+var _ = labColAmber
+var _ = labColGold
+var _ = labColIvory
+
+// ---------------------------------------------------------------------------
+// Room Dimensions (1 NDU = 1 meter)
+// ---------------------------------------------------------------------------
+
+const (
+	// Room envelope
+	roomWidth  = 12.0 // X: -6 to +6
+	roomDepth  = 16.0 // Z: -8 to +8
+	roomHeight = 4.5  // Y: 0 to 4.5
+
+	// Optical bench (experiment) — runs in X, parallel to desk
+	benchLen   = 6.0  // Total length (X: -3 to +3)
+	benchDepth = 0.8  // Z extent (narrow table)
+	benchY     = 0.9  // Surface height
+	benchThick = 0.08 // Top thickness
+	benchZ     = 1.0  // Center Z of bench (in front of platform)
+
+	// Raised platform (back of room, overlooking bench)
+	platZ0    = -7.5  // Back wall side (more room behind desk)
+	platZ1    = -3.5  // Edge facing bench
+	platWidth = 8.0   // X: -4 to +4
+	platY     = 0.6   // Platform height (3 steps × 0.2m)
+	stepDepth = 0.5   // Each step 0.5m deep
+	stepH     = 0.2   // Each step 0.2m rise
+
+	// Desk on platform
+	deskZ     = -5.5  // Center of desk
+	deskWidth = 4.0   // X extent
+	deskDepth = 1.0   // Z extent
+	deskH     = 0.75  // Height above platform
+	deskY     = platY + deskH
+
+	// Chair (behind desk, facing +Z toward bench)
+	chairZ     = -6.5  // Behind desk, scientist looks +Z over desk toward bench
+	chairSeatH = 0.45  // Seat height above platform
+	chairBackH = 0.8   // Back height above seat
+
+	// Camera (seated in chair, looking toward bench)
+	camStartX = 0.0
+	camStartY = platY + chairSeatH + 1.2 // platform + seat + seated eye
+	camStartZ = chairZ                     // At the chair
+)
+
+// ---------------------------------------------------------------------------
+// Lab Game
+// ---------------------------------------------------------------------------
+
+type LabGame struct {
+	host *engine.Host
+	rng  *rand.Rand
+
+	// Camera
+	yaw      matrix.Float
+	pitch    matrix.Float
+	mouseSen matrix.Float
+	lastMPos matrix.Vec2
+	hasLastM bool
+	seated   bool
+
+	heartbeat      chan struct{}
+	frameCount     int
+	frameTimeAccum float64
+	fpsLog         *os.File
+
+	// Active experiment room
+	room ExperimentRoom
+}
+
+func (g *LabGame) PluginRegistry() []reflect.Type {
+	return []reflect.Type{}
+}
+
+func (g *LabGame) ContentDatabase() (assets.Database, error) {
+	return assets.NewFileDatabase("content")
+}
+
+func (g *LabGame) Launch(host *engine.Host) {
+	g.host = host
+	g.rng = rand.New(rand.NewSource(42))
+	g.yaw = -math.Pi / 2 // Face down +Z (toward the bench)
+	g.pitch = -0.15       // Slight downward tilt
+	g.mouseSen = 0.002
+
+	// Camera
+	cam := host.PrimaryCamera()
+	cam.SetPosition(matrix.NewVec3(camStartX, camStartY, camStartZ))
+
+	// Build room
+	g.buildFloor(host)
+	g.buildWalls(host)
+	g.buildPlatform(host)
+	g.buildBench(host)
+	g.buildApparatus(host)
+
+	// Watchdog: SIGUSR1 force-kills if GPU hangs and ESC can't fire.
+	// From another terminal: kill -USR1 $(pgrep kaiju-ds)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGUSR1)
+	go func() {
+		<-sigCh
+		fmt.Println("SIGUSR1 received — force quit (watchdog)")
+		os.Exit(1)
+	}()
+
+	// Heartbeat watchdog: if the update loop stops ticking for 5 seconds
+	// (GPU hang), force-kill the process.
+	g.heartbeat = make(chan struct{}, 1)
+	go func() {
+		for {
+			select {
+			case <-g.heartbeat:
+			case <-time.After(5 * time.Second):
+				fmt.Println("WATCHDOG: update loop stalled for 5s — force quit")
+				os.Exit(1)
+			}
+		}
+	}()
+
+	// FPS log file
+	g.fpsLog, _ = os.Create("fps_log.txt")
+	if g.fpsLog != nil {
+		g.fpsLog.WriteString("timestamp,fps,frame_ms,particles\n")
+	}
+
+	// Hide cursor for FPS look (no LockCursor — it floods X11 with warp events)
+	host.Window.HideCursor()
+
+	// Update loop
+	host.Updater.AddUpdate(func(dt float64) {
+		select {
+		case g.heartbeat <- struct{}{}:
+		default:
+		}
+		g.update(dt)
+	})
+
+	// Initialize experiment room
+	g.room = NewDSRoom()
+	g.room.Setup(host)
+
+	fmt.Println("╔══════════════════════════════════════════════════════════╗")
+	fmt.Println("║  QBP Experiment 03: Double-Slit Lab                      ║")
+	fmt.Println("║  WASD: move  |  Mouse: look  |  Shift: sprint            ║")
+	fmt.Println("║  Q: sit/stand  |  1-4: views                             ║")
+	fmt.Println("║  5:Bach  6:Zeilinger  7:Tonomura  (standard QM)          ║")
+	fmt.Println("║  8:QBP-weak  9:QBP-strong  (quaternionic coupling)       ║")
+	fmt.Println("║  Enter: emitter  Space: freeze  +/-: rate  O: oracle     ║")
+	fmt.Println("║  R: reset  |  ESC: quit                                  ║")
+	fmt.Println("╚══════════════════════════════════════════════════════════╝")
+}
+
+// ---------------------------------------------------------------------------
+// Geometry helpers
+// ---------------------------------------------------------------------------
+
+func (g *LabGame) cube(host *engine.Host, pos, scale matrix.Vec3, color matrix.Color) {
+	mesh := rendering.NewMeshCube(host.MeshCache())
+	entity := engine.NewEntity(host.WorkGroup())
+	entity.Transform.SetPosition(pos)
+	entity.Transform.SetScale(scale)
+
+	mat, err := host.MaterialCache().Material(assets.MaterialDefinitionUnlit)
+	if err != nil {
+		fmt.Printf("Warning: material error: %v\n", err)
+		return
+	}
+
+	drawing := rendering.Drawing{
+		Material:  mat,
+		Mesh:      mesh,
+		Transform: &entity.Transform,
+		ShaderData: &shader_data_registry.ShaderDataUnlit{
+			ShaderDataBase: rendering.NewShaderDataBase(),
+			Color:          color,
+			UVs:            matrix.NewVec4(0, 0, 1, 1),
+		},
+		ViewCuller: &host.Cameras.Primary,
+	}
+	host.Drawings.AddDrawing(drawing)
+}
+
+// ---------------------------------------------------------------------------
+// Room Construction
+// ---------------------------------------------------------------------------
+
+func (g *LabGame) buildFloor(host *engine.Host) {
+	// Main floor
+	g.cube(host,
+		matrix.NewVec3(0, -0.05, 0),
+		matrix.NewVec3(roomWidth, 0.1, roomDepth),
+		labColFloor())
+
+	// Grid lines on floor (Steel color, thin strips along Z)
+	for x := matrix.Float(-roomWidth / 2); x <= roomWidth/2; x += 2 {
+		g.cube(host,
+			matrix.NewVec3(x, 0.001, 0),
+			matrix.NewVec3(0.02, 0.002, roomDepth),
+			labColSteel())
+	}
+	// Grid lines along X
+	for z := matrix.Float(-roomDepth / 2); z <= roomDepth/2; z += 2 {
+		g.cube(host,
+			matrix.NewVec3(0, 0.001, z),
+			matrix.NewVec3(roomWidth, 0.002, 0.02),
+			labColSteel())
+	}
+}
+
+func (g *LabGame) buildWalls(host *engine.Host) {
+	wallThick := matrix.Float(0.15)
+
+	// Back wall (behind platform)
+	g.cube(host,
+		matrix.NewVec3(0, roomHeight/2, -roomDepth/2),
+		matrix.NewVec3(roomWidth, roomHeight, wallThick),
+		labColVerdantNight())
+
+	// Front wall (behind detector)
+	g.cube(host,
+		matrix.NewVec3(0, roomHeight/2, roomDepth/2),
+		matrix.NewVec3(roomWidth, roomHeight, wallThick),
+		labColVerdantNight())
+
+	// Left wall
+	g.cube(host,
+		matrix.NewVec3(-roomWidth/2, roomHeight/2, 0),
+		matrix.NewVec3(wallThick, roomHeight, roomDepth),
+		labColVerdantNight())
+
+	// Right wall
+	g.cube(host,
+		matrix.NewVec3(roomWidth/2, roomHeight/2, 0),
+		matrix.NewVec3(wallThick, roomHeight, roomDepth),
+		labColVerdantNight())
+
+	// Ceiling
+	g.cube(host,
+		matrix.NewVec3(0, roomHeight, 0),
+		matrix.NewVec3(roomWidth, wallThick, roomDepth),
+		labColMidnight())
+}
+
+func (g *LabGame) buildPlatform(host *engine.Host) {
+	// 3 steps leading UP to the platform (lowest step furthest from platform)
+	for i := 0; i < 3; i++ {
+		stepNum := 3 - i // 3=tallest (at platform), 1=shortest (away from platform)
+		stepY := stepH * matrix.Float(stepNum)
+		stepZ := platZ1 + matrix.Float(i)*stepDepth
+		g.cube(host,
+			matrix.NewVec3(0, stepY/2, stepZ+stepDepth/2),
+			matrix.NewVec3(platWidth, stepY, stepDepth),
+			labColSteel())
+	}
+
+	// Platform top
+	platDepth := matrix.Float(platZ1 - platZ0)
+	g.cube(host,
+		matrix.NewVec3(0, platY/2, (platZ0+platZ1)/2),
+		matrix.NewVec3(platWidth, platY, platDepth),
+		labColSteel())
+
+	// Desk — Bronze colored slab on the platform
+	g.cube(host,
+		matrix.NewVec3(0, platY+deskH/2, deskZ),
+		matrix.NewVec3(deskWidth, deskH, deskDepth),
+		labColBronze())
+
+	// Desk edge trim (Brass strip along front edge)
+	g.cube(host,
+		matrix.NewVec3(0, platY+deskH, deskZ+deskDepth/2),
+		matrix.NewVec3(deskWidth+0.1, 0.03, 0.05),
+		labColBrass())
+
+	// Chair — between desk and platform edge
+	seatY := matrix.Float(platY + chairSeatH)
+	chairWidth := matrix.Float(0.5)
+	chairDepth := matrix.Float(0.5)
+
+	// Seat cushion
+	g.cube(host,
+		matrix.NewVec3(0, seatY, chairZ),
+		matrix.NewVec3(chairWidth, 0.08, chairDepth),
+		labColCopper())
+
+	legH := matrix.Float(chairSeatH - 0.04)
+
+	// Chair back (on -Z side, behind the scientist who faces +Z)
+	g.cube(host,
+		matrix.NewVec3(0, seatY+chairBackH/2, chairZ-chairDepth/2+0.03),
+		matrix.NewVec3(chairWidth, chairBackH, 0.05),
+		labColCopper())
+
+	// Chair base/pedestal (single center column)
+	g.cube(host,
+		matrix.NewVec3(0, platY+legH/2, chairZ),
+		matrix.NewVec3(0.08, legH, 0.08),
+		labColSteel())
+	// Chair base star (5-point, simplified as cross)
+	g.cube(host,
+		matrix.NewVec3(0, platY+0.04, chairZ),
+		matrix.NewVec3(0.5, 0.03, 0.08),
+		labColSteel())
+	g.cube(host,
+		matrix.NewVec3(0, platY+0.04, chairZ),
+		matrix.NewVec3(0.08, 0.03, 0.5),
+		labColSteel())
+
+	// Chair armrests
+	armY := seatY + 0.25
+	for _, x := range []matrix.Float{-chairWidth/2 + 0.02, chairWidth/2 - 0.02} {
+		g.cube(host,
+			matrix.NewVec3(x, armY, chairZ),
+			matrix.NewVec3(0.04, 0.04, chairDepth-0.1),
+			labColBrass())
+	}
+
+	// Flat monitor layout — 2×2 screens (double-stacked), facing -Z toward scientist
+	//
+	// Scientist eyes: (0, 2.25, -6.5), looking +Z
+	// All screens face -Z — simple flat panels, no L-shape.
+	// Wider screens (0.50 each) for readable text.
+
+	screenH := matrix.Float(0.35)
+	screenW := matrix.Float(0.50)  // Wider flat screens
+	gap := matrix.Float(0.03)      // Gap between stacked screens
+
+	bottomEdgeY := matrix.Float(camStartY - 0.05 - screenH - screenH/2)
+	botCenterY := bottomEdgeY + screenH/2
+	topCenterY := bottomEdgeY + screenH + gap + screenH/2
+
+	// Z position: on the desk, slightly forward
+	monitorZ := matrix.Float(deskZ + 0.4)
+
+	// Left and right centers (with gap between wings)
+	lCenterX := matrix.Float(-0.40) // Left wing center
+	rCenterX := matrix.Float(0.40)  // Right wing center
+
+	// === Left wing — 2 flat screens stacked ===
+	for _, cy := range []matrix.Float{botCenterY, topCenterY} {
+		// Screen face (faces -Z)
+		g.cube(host,
+			matrix.NewVec3(lCenterX, cy, monitorZ),
+			matrix.NewVec3(screenW, screenH, 0.025),
+			labColMidnight())
+		// Bezel
+		g.cube(host,
+			matrix.NewVec3(lCenterX, cy, monitorZ+0.015),
+			matrix.NewVec3(screenW+0.03, screenH+0.03, 0.005),
+			labColBrass())
+	}
+
+	// Left monitor arm (steel post, desk to bottom screen)
+	armBaseY := matrix.Float(deskY + 0.01)
+	armTopY := bottomEdgeY
+	armH := armTopY - armBaseY
+	g.cube(host,
+		matrix.NewVec3(lCenterX, armBaseY+armH/2, monitorZ),
+		matrix.NewVec3(0.04, armH, 0.04),
+		labColSteel())
+
+	// === Right wing — 2 flat screens stacked ===
+	for _, cy := range []matrix.Float{botCenterY, topCenterY} {
+		// Screen face (faces -Z)
+		g.cube(host,
+			matrix.NewVec3(rCenterX, cy, monitorZ),
+			matrix.NewVec3(screenW, screenH, 0.025),
+			labColMidnight())
+		// Bezel
+		g.cube(host,
+			matrix.NewVec3(rCenterX, cy, monitorZ+0.015),
+			matrix.NewVec3(screenW+0.03, screenH+0.03, 0.005),
+			labColBrass())
+	}
+
+	// Right monitor arm
+	g.cube(host,
+		matrix.NewVec3(rCenterX, armBaseY+armH/2, monitorZ),
+		matrix.NewVec3(0.04, armH, 0.04),
+		labColSteel())
+
+	// === Center — clear view to bench ===
+	g.cube(host,
+		matrix.NewVec3(0, deskY+0.015, deskZ+0.3),
+		matrix.NewVec3(0.40, 0.015, 0.13),
+		labColMidnight())
+	g.cube(host,
+		matrix.NewVec3(0.35, deskY+0.01, deskZ+0.3),
+		matrix.NewVec3(0.12, 0.01, 0.15),
+		labColSteel())
+}
+
+func (g *LabGame) buildBench(host *engine.Host) {
+	// Bench top (optical table surface) — runs in X, parallel to desk
+	g.cube(host,
+		matrix.NewVec3(0, benchY, benchZ),
+		matrix.NewVec3(benchLen, benchThick, benchDepth),
+		labColBronze())
+
+	// Bench legs (4 corners)
+	legH := matrix.Float(benchY - benchThick/2)
+	legW := matrix.Float(0.08)
+	halfLen := matrix.Float(benchLen/2 - 0.15)
+	halfDep := matrix.Float(benchDepth/2 - 0.1)
+	for _, x := range []matrix.Float{-halfLen, halfLen} {
+		for _, z := range []matrix.Float{benchZ - halfDep, benchZ + halfDep} {
+			g.cube(host,
+				matrix.NewVec3(x, legH/2, z),
+				matrix.NewVec3(legW, legH, legW),
+				labColSteel())
+		}
+	}
+
+	// Bench edge trim (Brass strip around perimeter)
+	trimH := matrix.Float(0.02)
+	trimY := matrix.Float(benchY + benchThick/2)
+	// Long edges (along X)
+	g.cube(host,
+		matrix.NewVec3(0, trimY, benchZ-benchDepth/2),
+		matrix.NewVec3(benchLen, trimH, 0.02),
+		labColBrass())
+	g.cube(host,
+		matrix.NewVec3(0, trimY, benchZ+benchDepth/2),
+		matrix.NewVec3(benchLen, trimH, 0.02),
+		labColBrass())
+	// Short edges (along Z)
+	g.cube(host,
+		matrix.NewVec3(-benchLen/2, trimY, benchZ),
+		matrix.NewVec3(0.02, trimH, benchDepth),
+		labColBrass())
+	g.cube(host,
+		matrix.NewVec3(benchLen/2, trimY, benchZ),
+		matrix.NewVec3(0.02, trimH, benchDepth),
+		labColBrass())
+}
+
+func (g *LabGame) buildApparatus(host *engine.Host) {
+	appY := matrix.Float(benchY + benchThick/2) // Top of bench surface
+
+	// Apparatus runs along X axis (left-to-right on bench)
+	// Source at -X, barrier at center, detector at +X
+	srcX := matrix.Float(-benchLen/2 + 0.5)
+	barrierX := matrix.Float(0)
+	screenX := matrix.Float(benchLen/2 - 0.5)
+
+	// Source — small emitter box
+	g.cube(host,
+		matrix.NewVec3(srcX, appY+0.15, benchZ),
+		matrix.NewVec3(0.3, 0.3, 0.3),
+		labColCopper())
+	// Emitter aperture (dark hole on face toward detector)
+	g.cube(host,
+		matrix.NewVec3(srcX+0.16, appY+0.15, benchZ),
+		matrix.NewVec3(0.02, 0.06, 0.06),
+		labColMidnight())
+
+	// Barrier — vertical plate with two slit gaps (now in YZ plane)
+	barrierH := matrix.Float(0.5)
+	barrierW := matrix.Float(0.8)  // Z extent (height of barrier plate in Z)
+	slitGap := matrix.Float(0.15)  // Separation between slits (in Z)
+	slitW := matrix.Float(0.03)    // Each slit width (in Z)
+
+	// Bottom solid section
+	botW := (barrierW - slitGap) / 2 - slitW/2
+	g.cube(host,
+		matrix.NewVec3(barrierX, appY+barrierH/2, benchZ-(slitGap/2+slitW/2+botW/2)),
+		matrix.NewVec3(0.03, barrierH, botW),
+		labColBrass())
+
+	// Center solid section (between slits)
+	g.cube(host,
+		matrix.NewVec3(barrierX, appY+barrierH/2, benchZ),
+		matrix.NewVec3(0.03, barrierH, slitGap-slitW),
+		labColBrass())
+
+	// Top solid section
+	g.cube(host,
+		matrix.NewVec3(barrierX, appY+barrierH/2, benchZ+(slitGap/2+slitW/2+botW/2)),
+		matrix.NewVec3(0.03, barrierH, botW),
+		labColBrass())
+
+	// Barrier frame (Copper surround)
+	frameW := matrix.Float(0.04)
+	// Top bar
+	g.cube(host,
+		matrix.NewVec3(barrierX, appY+barrierH+frameW/2, benchZ),
+		matrix.NewVec3(0.05, frameW, barrierW+frameW*2),
+		labColCopper())
+	// Bottom bar
+	g.cube(host,
+		matrix.NewVec3(barrierX, appY-frameW/2, benchZ),
+		matrix.NewVec3(0.05, frameW, barrierW+frameW*2),
+		labColCopper())
+	// Near bar (toward camera)
+	g.cube(host,
+		matrix.NewVec3(barrierX, appY+barrierH/2, benchZ-(barrierW/2+frameW/2)),
+		matrix.NewVec3(0.05, barrierH+frameW*2, frameW),
+		labColCopper())
+	// Far bar
+	g.cube(host,
+		matrix.NewVec3(barrierX, appY+barrierH/2, benchZ+(barrierW/2+frameW/2)),
+		matrix.NewVec3(0.05, barrierH+frameW*2, frameW),
+		labColCopper())
+
+	// Detector screen — tall flat panel (in YZ plane)
+	screenH := matrix.Float(0.6)
+	screenD := matrix.Float(1.0) // Z extent
+	// Screen surface (where hits land)
+	g.cube(host,
+		matrix.NewVec3(screenX, appY+screenH/2, benchZ),
+		matrix.NewVec3(0.02, screenH, screenD),
+		labColIvory())
+	// Screen frame
+	g.cube(host,
+		matrix.NewVec3(screenX+0.02, appY+screenH/2, benchZ),
+		matrix.NewVec3(0.02, screenH+0.06, screenD+0.06),
+		labColCopper())
+
+	// Beam path indicator — faint dashed line along bench (X axis)
+	dashLen := matrix.Float(0.2)
+	dashGap := matrix.Float(0.2)
+	for x := srcX + 0.4; x < screenX-0.3; x += dashLen + dashGap {
+		g.cube(host,
+			matrix.NewVec3(x+dashLen/2, appY+0.005, benchZ),
+			matrix.NewVec3(dashLen, 0.005, 0.01),
+			labColSteel())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Update Loop — FPS Camera
+// ---------------------------------------------------------------------------
+
+func (g *LabGame) update(dt float64) {
+	kb := g.host.Window.Keyboard
+	mouse := &g.host.Window.Mouse
+
+	// FPS + particle count logging (to file and stderr)
+	g.frameCount++
+	g.frameTimeAccum += dt
+	if g.frameTimeAccum >= 1.0 {
+		fps := float64(g.frameCount) / g.frameTimeAccum
+		frameMs := (g.frameTimeAccum / float64(g.frameCount)) * 1000
+		particles := 0
+		if dsRoom, ok := g.room.(*DSRoom); ok {
+			particles = dsRoom.detector.TotalHits
+		}
+		if g.fpsLog != nil {
+			fmt.Fprintf(g.fpsLog, "%.0f,%.1f,%.2f,%d\n", float64(time.Now().UnixMilli()), fps, frameMs, particles)
+			g.fpsLog.Sync()
+		}
+		fmt.Fprintf(os.Stderr, "FPS: %.1f  (frame: %.2fms)  particles: %d\n", fps, frameMs, particles)
+		g.frameCount = 0
+		g.frameTimeAccum = 0
+	}
+
+	// Quit: ESC or Ctrl+Alt+Esc
+	if kb.KeyDown(hid.KeyboardKeyEscape) {
+		fmt.Println("ESC — quit")
+		os.Exit(0)
+	}
+
+	// Mouse look — raw delta between frames, no LockCursor.
+	// Warp to center only when cursor nears the window edge.
+	mp := mouse.Position()
+	if g.hasLastM {
+		dx := matrix.Float(mp.X()-g.lastMPos.X()) * g.mouseSen
+		dy := matrix.Float(mp.Y()-g.lastMPos.Y()) * g.mouseSen
+		g.yaw += dx
+		g.pitch += dy
+		if g.pitch > math.Pi/2-0.1 {
+			g.pitch = math.Pi/2 - 0.1
+		}
+		if g.pitch < -math.Pi/2+0.1 {
+			g.pitch = -math.Pi/2 + 0.1
+		}
+	}
+	g.lastMPos = mp
+	g.hasLastM = true
+
+	// Warp cursor to center if it drifts near the window edge
+	w, h := g.host.Window.Width(), g.host.Window.Height()
+	margin := 50
+	sx, sy := int(mouse.SX), int(mouse.SY)
+	if sx < margin || sx > w-margin || sy < margin || sy > h-margin {
+		g.host.Window.SetCursorPosition(w/2, h/2)
+		g.hasLastM = false // skip next delta to avoid jump from warp
+	}
+
+	// Movement (disabled when seated)
+	cam := g.host.PrimaryCamera()
+	pos := cam.Position()
+
+	if !g.seated {
+		speed := matrix.Float(8.0 * dt)
+		if kb.KeyHeld(hid.KeyboardKeyLeftShift) {
+			speed *= 2.5
+		}
+
+		forward := matrix.NewVec3(
+			matrix.Float(math.Cos(float64(g.yaw))),
+			0,
+			matrix.Float(math.Sin(float64(g.yaw))))
+		right := matrix.NewVec3(
+			matrix.Float(-math.Sin(float64(g.yaw))),
+			0,
+			matrix.Float(math.Cos(float64(g.yaw))))
+
+		if kb.KeyHeld(hid.KeyboardKeyW) {
+			pos = pos.Add(forward.Scale(speed))
+		}
+		if kb.KeyHeld(hid.KeyboardKeyS) {
+			pos = pos.Subtract(forward.Scale(speed))
+		}
+		if kb.KeyHeld(hid.KeyboardKeyA) {
+			pos = pos.Subtract(right.Scale(speed))
+		}
+		if kb.KeyHeld(hid.KeyboardKeyD) {
+			pos = pos.Add(right.Scale(speed))
+		}
+	}
+
+	// Preset views (KeyDown = first frame only)
+	if kb.KeyDown(hid.KeyboardKey1) {
+		// Overview — behind desk, looking toward bench
+		pos = matrix.NewVec3(0, camStartY, camStartZ)
+		g.yaw = math.Pi / 2
+		g.pitch = -0.15
+		g.hasLastM = false
+	}
+	if kb.KeyDown(hid.KeyboardKey2) {
+		// Slit close-up — in front of barrier, facing it
+		pos = matrix.NewVec3(-0.8, benchY+0.4, benchZ-1.0)
+		g.yaw = math.Pi / 2
+		g.pitch = -0.1
+		g.hasLastM = false
+	}
+	if kb.KeyDown(hid.KeyboardKey3) {
+		// Detector screen — looking at it from the source side
+		pos = matrix.NewVec3(benchLen/2+0.3, benchY+0.4, benchZ-0.8)
+		g.yaw = math.Pi
+		g.pitch = -0.05
+		g.hasLastM = false
+	}
+	if kb.KeyDown(hid.KeyboardKey4) {
+		// Top-down — bird's eye
+		pos = matrix.NewVec3(0, 4.0, benchZ)
+		g.yaw = math.Pi / 2
+		g.pitch = -math.Pi/2 + 0.1
+		g.hasLastM = false
+	}
+
+	// Sit/Stand toggle (Q key) — must be within 1m of chair
+	if kb.KeyDown(hid.KeyboardKeyQ) {
+		chairPos := matrix.NewVec3(0, 0, chairZ)
+		playerXZ := matrix.NewVec3(pos.X(), 0, pos.Z())
+		dist := chairPos.Subtract(playerXZ).Length()
+		if !g.seated && dist < 1.0 {
+			// Sit down — snap to chair, face desk/bench
+			// Pitch = -0.25 for "dashboard view": both desk controls AND monitors visible
+			g.seated = true
+			pos = matrix.NewVec3(0, camStartY, chairZ)
+			g.yaw = math.Pi / 2  // Face +Z toward bench
+			g.pitch = -0.25
+			g.hasLastM = false
+		} else if g.seated {
+			// Stand up — rise to standing height, step back from chair
+			g.seated = false
+			standY := matrix.Float(platY + 1.7) // Standing eye height on platform
+			pos = matrix.NewVec3(0, standY, chairZ-0.5)
+			g.hasLastM = false
+		}
+	}
+
+	// When seated: disable WASD movement, allow mouse look only
+	if g.seated {
+		pos = matrix.NewVec3(0, camStartY, chairZ)
+	}
+
+	// Wall collision — clamp position inside room bounds
+	wallMargin := matrix.Float(0.3)
+	minX := matrix.Float(-roomWidth/2) + wallMargin
+	maxX := matrix.Float(roomWidth/2) - wallMargin
+	minZ := matrix.Float(-roomDepth/2) + wallMargin
+	maxZ := matrix.Float(roomDepth/2) - wallMargin
+	minY := matrix.Float(0.5) // Don't go below eye height
+	maxY := matrix.Float(roomHeight) - wallMargin
+
+	px, py, pz := pos.X(), pos.Y(), pos.Z()
+	if px < minX { px = minX }
+	if px > maxX { px = maxX }
+	if py < minY { py = minY }
+	if py > maxY { py = maxY }
+	if pz < minZ { pz = minZ }
+	if pz > maxZ { pz = maxZ }
+	pos = matrix.NewVec3(px, py, pz)
+
+	cam.SetPosition(pos)
+	target := pos.Add(matrix.NewVec3(
+		matrix.Float(math.Cos(float64(g.pitch))*math.Cos(float64(g.yaw))),
+		matrix.Float(math.Sin(float64(g.pitch))),
+		matrix.Float(math.Cos(float64(g.pitch))*math.Sin(float64(g.yaw)))))
+	cam.SetLookAt(target)
+
+	// Update experiment room
+	if g.room != nil {
+		if dsRoom, ok := g.room.(*DSRoom); ok {
+			dsRoom.HandleInput(g.host)
+		}
+		g.room.Update(dt)
+	}
+}

--- a/src/bakeoff/kaiju/game/lab_game.go
+++ b/src/bakeoff/kaiju/game/lab_game.go
@@ -382,8 +382,8 @@ func (g *LabGame) buildPlatform(host *engine.Host) {
 	monitorZ := matrix.Float(deskZ + 0.4)
 
 	// Left and right centers (with gap between wings)
-	lCenterX := matrix.Float(-0.40) // Left wing center
-	rCenterX := matrix.Float(0.40)  // Right wing center
+	lCenterX := matrix.Float(-0.65) // Left wing center
+	rCenterX := matrix.Float(0.65)  // Right wing center
 
 	// === Left wing — 2 flat screens stacked ===
 	for _, cy := range []matrix.Float{botCenterY, topCenterY} {

--- a/src/bakeoff/kaiju/game/lab_monitors.go
+++ b/src/bakeoff/kaiju/game/lab_monitors.go
@@ -57,7 +57,7 @@ func NewMonitorContent(host *engine.Host) *MonitorContent {
 //   Two stacked — use bottom one for histogram
 
 func (mc *MonitorContent) buildHistogramMonitor(host *engine.Host) {
-	rCenterX := matrix.Float(0.40) // Match flat monitor layout
+	rCenterX := matrix.Float(0.65) // Match flat monitor layout
 	screenW := matrix.Float(0.50)
 	screenH := matrix.Float(0.35)
 	bottomEdgeY := matrix.Float(camStartY - 0.05 - screenH - screenH/2)

--- a/src/bakeoff/kaiju/game/lab_monitors.go
+++ b/src/bakeoff/kaiju/game/lab_monitors.go
@@ -1,0 +1,158 @@
+//go:build !editor
+
+// Virtual Monitor System for QBP Lab
+//
+// Each physical monitor on the desk is a "VM" that displays 3D content on its
+// surface. Since Kaiju doesn't expose the Renderer to game code (needed for
+// texture.WritePixels), we render monitor content as 3D entities positioned
+// ON the monitor surface — colored cubes for histogram bars, verdict blocks, etc.
+//
+// This approach (recommended by Gemini review) is faster than texture uploads
+// and stays within Kaiju's entity/transform model.
+
+package main
+
+import (
+	"kaiju/engine"
+	"kaiju/engine/assets"
+	"kaiju/matrix"
+	"kaiju/registry/shader_data_registry"
+	"kaiju/rendering"
+)
+
+// MonitorContent represents the 3D entities rendered on a monitor surface.
+// Verdict and stats display is now handled by MonitorTextSystem (3D SDF text).
+// This struct retains only the histogram bars on the right monitor.
+type MonitorContent struct {
+	host *engine.Host
+
+	// Histogram bars (right monitor)
+	histBars    []*engine.Entity
+	histDrawing []rendering.Drawing
+	numBars     int
+}
+
+const monitorHistBars = 40 // Number of histogram bars on monitor
+
+// NewMonitorContent creates the 3D entities for both monitors.
+// Left monitor = stats/verdict, Right monitor = histogram.
+func NewMonitorContent(host *engine.Host) *MonitorContent {
+	mc := &MonitorContent{
+		host:    host,
+		numBars: monitorHistBars,
+	}
+	mc.buildHistogramMonitor(host)
+	return mc
+}
+
+// ---------------------------------------------------------------------------
+// Right Monitor — Histogram (3D bars on the XY slab)
+// ---------------------------------------------------------------------------
+//
+// Right monitor XY slab is at:
+//   center X = rCornerX - halfW/2 = 0.65 - 0.15 = 0.50
+//   center Z = cornerZ = deskZ + 0.4 = -5.1
+//   The slab faces -Z (toward scientist)
+//   Screen area: halfW=0.30 wide (X), screenH=0.35 tall (Y)
+//   Two stacked — use bottom one for histogram
+
+func (mc *MonitorContent) buildHistogramMonitor(host *engine.Host) {
+	rCenterX := matrix.Float(0.40) // Match flat monitor layout
+	screenW := matrix.Float(0.50)
+	screenH := matrix.Float(0.35)
+	bottomEdgeY := matrix.Float(camStartY - 0.05 - screenH - screenH/2)
+	monitorZ := matrix.Float(deskZ + 0.4)
+
+	// Histogram bars on the bottom-right flat screen
+	barAreaW := screenW * 0.85 // Leave margin
+	barW := barAreaW / matrix.Float(monitorHistBars)
+	barMaxH := screenH * 0.8
+	startX := rCenterX - screenW/2 + (screenW-barAreaW)/2 + barW/2
+
+	mc.histBars = make([]*engine.Entity, monitorHistBars)
+	mc.histDrawing = make([]rendering.Drawing, monitorHistBars)
+
+	for i := 0; i < monitorHistBars; i++ {
+		mesh := rendering.NewMeshCube(host.MeshCache())
+		entity := engine.NewEntity(host.WorkGroup())
+
+		x := startX + matrix.Float(i)*barW
+		y := bottomEdgeY + barMaxH*0.01 // Base of bar
+		z := monitorZ - 0.015           // Slightly in front of screen surface
+
+		entity.Transform.SetPosition(matrix.NewVec3(x, y, z))
+		entity.Transform.SetScale(matrix.NewVec3(barW*0.8, 0.001, 0.005)) // Thin, almost invisible initially
+
+		mat, err := host.MaterialCache().Material(assets.MaterialDefinitionUnlit)
+		if err != nil {
+			continue
+		}
+
+		sd := &shader_data_registry.ShaderDataUnlit{
+			ShaderDataBase: rendering.NewShaderDataBase(),
+			Color:          labColOchre(),
+			UVs:            matrix.NewVec4(0, 0, 1, 1),
+		}
+
+		drawing := rendering.Drawing{
+			Material:   mat,
+			Mesh:       mesh,
+			Transform:  &entity.Transform,
+			ShaderData: sd,
+			ViewCuller: &host.Cameras.Primary,
+		}
+		host.Drawings.AddDrawing(drawing)
+
+		mc.histBars[i] = entity
+		mc.histDrawing[i] = drawing
+	}
+
+	_ = barMaxH // used in UpdateHistogram
+}
+
+// ---------------------------------------------------------------------------
+// Per-frame Updates
+// ---------------------------------------------------------------------------
+
+// UpdateHistogram updates the 3D histogram bars from detector data.
+func (mc *MonitorContent) UpdateHistogram(histogram [dsHistogramBins]int) {
+	// Find max bin value
+	maxBin := 1
+	for _, v := range histogram {
+		if v > maxBin {
+			maxBin = v
+		}
+	}
+
+	screenH := matrix.Float(0.35)
+	barMaxH := screenH * 0.8
+	bottomEdgeY := matrix.Float(camStartY - 0.05 - screenH - screenH/2)
+
+	binsPerBar := dsHistogramBins / monitorHistBars
+
+	for i := 0; i < monitorHistBars && i < len(mc.histBars); i++ {
+		// Sum bins for this bar
+		total := 0
+		for j := 0; j < binsPerBar; j++ {
+			idx := i*binsPerBar + j
+			if idx < dsHistogramBins {
+				total += histogram[idx]
+			}
+		}
+
+		h := matrix.Float(total) / matrix.Float(maxBin) * barMaxH
+		if h < 0.001 {
+			h = 0.001
+		}
+
+		entity := mc.histBars[i]
+		pos := entity.Transform.Position()
+		screenW := matrix.Float(0.50)
+		barAreaW := screenW * 0.85
+		barW := barAreaW / matrix.Float(monitorHistBars)
+
+		entity.Transform.SetScale(matrix.NewVec3(barW*0.8, h, 0.005))
+		entity.Transform.SetPosition(matrix.NewVec3(pos.X(), bottomEdgeY+h/2, pos.Z()))
+	}
+}
+

--- a/src/bakeoff/kaiju/game/lab_physics.go
+++ b/src/bakeoff/kaiju/game/lab_physics.go
@@ -1,0 +1,256 @@
+//go:build !editor
+
+// Physics engine for the QBP Virtual Lab.
+//
+// Implements BOTH standard Fraunhofer AND QBP quaternionic physics:
+//
+//   Standard:  I(x) = cos²(π·d·x / λ·L) · sinc²(π·a·x / λ·L)
+//   QBP:       I(x) = (1-η) · I_fraunhofer(x) + η
+//
+// where η is the quaternionic fraction — the central QBP prediction.
+// Proven in Lean: proofs/QBP/Experiments/DoubleSlit.lean §5b
+//
+// The float functions here mirror proofs/QBP/Oracle/FloatCompute.lean
+// and are validated against the Lean oracle (tests/oracle_predictions.json).
+
+package main
+
+import (
+	"kaiju/qbp"
+	"math"
+	"math/rand"
+)
+
+// Experimental presets — grounded in real double-slit experiments.
+// U1 is the quaternionic coupling energy (QBP-specific parameter).
+// When U1=0, the simulation reduces to standard QM (proven: scenarioA_visibility).
+type Preset struct {
+	ID         string
+	Label      string
+	SlitSep    float64 // d (meters)
+	Wavelength float64 // λ (meters)
+	ScreenDist float64 // L (meters)
+	SlitWidth  float64 // a (meters)
+	U1         float64 // Quaternionic coupling energy U₁ (Joules). 0 = standard QM.
+}
+
+var presets = []Preset{
+	{
+		ID:         "bach_2013",
+		Label:      "Bach 2013 (electrons)",
+		SlitSep:    272e-9,
+		Wavelength: 50e-12,
+		ScreenDist: 0.24,
+		SlitWidth:  62e-9,
+		U1:         0, // Standard QM baseline
+	},
+	{
+		ID:         "zeilinger_1988",
+		Label:      "Zeilinger 1988 (neutrons)",
+		SlitSep:    126.5e-6,
+		Wavelength: 1.845e-9,
+		ScreenDist: 5.0,
+		SlitWidth:  21.8e-6,
+		U1:         0, // Standard QM baseline
+	},
+	{
+		ID:         "tonomura_1989",
+		Label:      "Tonomura 1989 (electrons)",
+		SlitSep:    1.0e-6,
+		Wavelength: 5.5e-12,
+		ScreenDist: 1.0,
+		SlitWidth:  1.0e-7,
+		U1:         0, // Standard QM baseline
+	},
+	// QBP test presets — non-zero U₁ demonstrates quaternionic effects
+	{
+		ID:         "qbp_weak",
+		Label:      "QBP: Weak coupling",
+		SlitSep:    1.0e-6,
+		Wavelength: 5.5e-12,
+		ScreenDist: 1.0,
+		SlitWidth:  1.0e-7,
+		U1:         1e-6, // Weak coupling → small η → slight visibility reduction
+	},
+	{
+		ID:         "qbp_strong",
+		Label:      "QBP: Strong coupling",
+		SlitSep:    1.0e-6,
+		Wavelength: 5.5e-12,
+		ScreenDist: 1.0,
+		SlitWidth:  1.0e-7,
+		U1:         1e-3, // Strong coupling → large η → significant visibility loss
+	},
+}
+
+func presetByID(id string) *Preset {
+	for i := range presets {
+		if presets[i].ID == id {
+			return &presets[i]
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// QBP Float Oracle Functions — delegated to kaiju/qbp package
+//
+// The qbp package contains pure math (no Vulkan dependency), enabling:
+// 1. Differential testing against Lean oracle without GPU
+// 2. Future hot-swap to Lean FFI, SciLean, or PhysLean backends
+// ---------------------------------------------------------------------------
+
+// Convenience wrappers — delegate to qbp package for testability.
+func QBPVisibility(imax, imin float64) float64                                  { return qbp.Visibility(imax, imin) }
+func QBPQuatFraction(normSq0, normSq1 float64) float64                         { return qbp.QuatFraction(normSq0, normSq1) }
+func QBPCouplingDecomposition(u0, u1, a0, b0, a1, b1 float64) (float64, float64, float64, float64) { return qbp.CouplingDecomposition(u0, u1, a0, b0, a1, b1) }
+func QBPDecayConstant(u1, d float64) float64                                   { return qbp.DecayConstant(u1, d) }
+func QBPDecayLength(kappa float64) float64                                     { return qbp.DecayLength(kappa) }
+func QBPFraunhoferIntensity(i0, d, lambda, l, x float64) float64              { return qbp.FraunhoferIntensity(i0, d, lambda, l, x) }
+func QBPFringeSpacing(lambda, l, d float64) float64                            { return qbp.FringeSpacing(lambda, l, d) }
+func QBPNormSqSymp(re, imI, imJ, imK float64) float64                         { return qbp.NormSqSymp(re, imI, imJ, imK) }
+
+// ---------------------------------------------------------------------------
+// LabPhysicsEngine
+// ---------------------------------------------------------------------------
+
+// LabPhysicsEngine computes QBP-modified intensity and samples hit positions.
+type LabPhysicsEngine struct {
+	SlitSep    float64
+	Wavelength float64
+	ScreenDist float64
+	SlitWidth  float64
+	U1         float64 // Quaternionic coupling energy (QBP). 0 = standard QM.
+	rng        *rand.Rand
+}
+
+func NewLabPhysicsEngine() *LabPhysicsEngine {
+	// Default to Tonomura parameters (standard QM, U1=0)
+	p := presets[2]
+	return &LabPhysicsEngine{
+		SlitSep:    p.SlitSep,
+		Wavelength: p.Wavelength,
+		ScreenDist: p.ScreenDist,
+		SlitWidth:  p.SlitWidth,
+		U1:         p.U1,
+		rng:        rand.New(rand.NewSource(42)),
+	}
+}
+
+func (e *LabPhysicsEngine) FringeSpacing() float64 {
+	return e.Wavelength * e.ScreenDist / e.SlitSep
+}
+
+// Eta computes the quaternionic fraction η at the detector.
+// In Model A (DoubleSlit.lean §5b): η determines visibility via V = 1 - η.
+//
+// Physics: The quaternionic component ψ₁ is generated at the slit barrier
+// (where U₁ ≠ 0) and decays during free propagation to the detector.
+// η = η₀ · exp(-κ·L) where κ ∝ |U₁|/d and L is the screen distance.
+//
+// When U₁ = 0: η = 0, standard QM (proven: scenarioA_visibility).
+// When U₁ → ∞: η → 1, no interference (proven: scenarioB_visibility).
+func (e *LabPhysicsEngine) Eta() float64 {
+	if e.U1 == 0 {
+		return 0 // Standard QM: no quaternionic coupling
+	}
+
+	// Initial quaternionic fraction at the slit barrier.
+	// Simplified model: η₀ scales with U₁ relative to kinetic energy.
+	// η₀ = U₁² / (E_kinetic² + U₁²) — smooth saturation at 1.
+	hbar := 1.0545718e-34          // ℏ (J·s)
+	mass := 9.1093837e-31          // electron mass (kg)
+	v := hbar / (mass * e.Wavelength * 1e10) // velocity from de Broglie (simplified)
+	eKinetic := 0.5 * mass * v * v
+	eta0 := e.U1 * e.U1 / (eKinetic*eKinetic + e.U1*e.U1)
+
+	// Decay during propagation: κ = |U₁| · d (simplified, mirrors Lean decayConstant)
+	kappa := QBPDecayConstant(math.Abs(e.U1), e.SlitSep)
+	eta := eta0 * math.Exp(-kappa*e.ScreenDist)
+
+	if eta > 1 {
+		eta = 1
+	}
+	return eta
+}
+
+// Visibility computes V = 1 - η (Model A, proven in DoubleSlit.lean §5b).
+func (e *LabPhysicsEngine) Visibility() float64 {
+	return 1 - e.Eta()
+}
+
+// FraunhoferIntensity computes the classical part: cos²·sinc².
+func (e *LabPhysicsEngine) FraunhoferIntensity(x float64) float64 {
+	argD := math.Pi * e.SlitSep * x / (e.Wavelength * e.ScreenDist)
+	argA := math.Pi * e.SlitWidth * x / (e.Wavelength * e.ScreenDist)
+
+	cos2 := math.Cos(argD) * math.Cos(argD)
+
+	sinc2 := 1.0
+	if math.Abs(argA) > 1e-12 {
+		s := math.Sin(argA) / argA
+		sinc2 = s * s
+	}
+	return cos2 * sinc2
+}
+
+// Intensity computes the QBP-modified intensity at position x.
+//
+// QBP Model A (proven in DoubleSlit.lean §5b):
+//   I(x) = (1-η) · I_fraunhofer(x) + η
+//
+// When η=0 (U₁=0): I(x) = I_fraunhofer(x)  — standard QM
+// When η=1 (full coupling): I(x) = 1  — flat, no fringes (which-path)
+//
+// The maximum is always 1 (at x=0 where I_fraunhofer=1), which keeps
+// rejection sampling efficient.
+func (e *LabPhysicsEngine) Intensity(x float64) float64 {
+	eta := e.Eta()
+	return (1-eta)*e.FraunhoferIntensity(x) + eta
+}
+
+// SampleHitPosition draws a hit position from I(x) via rejection sampling.
+func (e *LabPhysicsEngine) SampleHitPosition() float64 {
+	halfWidth := 5.0 * e.FringeSpacing()
+	for {
+		x := (e.rng.Float64()*2 - 1) * halfWidth
+		if e.rng.Float64() < e.Intensity(x) {
+			return x
+		}
+	}
+}
+
+// ApplyPreset sets all physics parameters from a named preset.
+func (e *LabPhysicsEngine) ApplyPreset(id string) bool {
+	p := presetByID(id)
+	if p == nil {
+		return false
+	}
+	e.SlitSep = p.SlitSep
+	e.Wavelength = p.Wavelength
+	e.ScreenDist = p.ScreenDist
+	e.SlitWidth = p.SlitWidth
+	e.U1 = p.U1
+	return true
+}
+
+// LabCoordMapper converts between physical meters and Normalized Display Units.
+type LabCoordMapper struct {
+	PhysHalfWidth float64
+	NDUHalfWidth  float64
+}
+
+func NewLabCoordMapper(fringeSpacing float64) *LabCoordMapper {
+	return &LabCoordMapper{
+		PhysHalfWidth: 5.0 * fringeSpacing,
+		NDUHalfWidth:  5.0,
+	}
+}
+
+func (cm *LabCoordMapper) PhysToNDU(x float64) float64 {
+	return (x / cm.PhysHalfWidth) * cm.NDUHalfWidth
+}
+
+func (cm *LabCoordMapper) Update(fringeSpacing float64) {
+	cm.PhysHalfWidth = 5.0 * fringeSpacing
+}

--- a/src/bakeoff/kaiju/game/lab_physics.go
+++ b/src/bakeoff/kaiju/game/lab_physics.go
@@ -21,6 +21,12 @@ import (
 	"math/rand"
 )
 
+// Particle masses (SI, kg).
+const (
+	electronMass = 9.1093837015e-31
+	neutronMass  = 1.67492749804e-27
+)
+
 // Experimental presets — grounded in real double-slit experiments.
 // U1 is the quaternionic coupling energy (QBP-specific parameter).
 // When U1=0, the simulation reduces to standard QM (proven: scenarioA_visibility).
@@ -32,6 +38,7 @@ type Preset struct {
 	ScreenDist float64 // L (meters)
 	SlitWidth  float64 // a (meters)
 	U1         float64 // Quaternionic coupling energy U₁ (Joules). 0 = standard QM.
+	Mass       float64 // Particle mass (kg). Use electronMass or neutronMass.
 }
 
 var presets = []Preset{
@@ -43,6 +50,7 @@ var presets = []Preset{
 		ScreenDist: 0.24,
 		SlitWidth:  62e-9,
 		U1:         0, // Standard QM baseline
+		Mass:       electronMass,
 	},
 	{
 		ID:         "zeilinger_1988",
@@ -52,6 +60,7 @@ var presets = []Preset{
 		ScreenDist: 5.0,
 		SlitWidth:  21.8e-6,
 		U1:         0, // Standard QM baseline
+		Mass:       neutronMass,
 	},
 	{
 		ID:         "tonomura_1989",
@@ -61,8 +70,11 @@ var presets = []Preset{
 		ScreenDist: 1.0,
 		SlitWidth:  1.0e-7,
 		U1:         0, // Standard QM baseline
+		Mass:       electronMass,
 	},
-	// QBP test presets — non-zero U₁ demonstrates quaternionic effects
+	// QBP test presets — non-zero U₁ demonstrates quaternionic effects.
+	// U₁ values calibrated against E_kinetic ≈ 8.0e-15 J (Tonomura-like electrons).
+	// η₀ = U₁²/(E_k² + U₁²): weak → η₀≈0.09, strong → η₀≈0.69.
 	{
 		ID:         "qbp_weak",
 		Label:      "QBP: Weak coupling",
@@ -70,7 +82,8 @@ var presets = []Preset{
 		Wavelength: 5.5e-12,
 		ScreenDist: 1.0,
 		SlitWidth:  1.0e-7,
-		U1:         1e-6, // Weak coupling → small η → slight visibility reduction
+		U1:         2.5e-15, // η₀≈0.09, V≈0.91 — subtle visibility reduction
+		Mass:       electronMass,
 	},
 	{
 		ID:         "qbp_strong",
@@ -79,7 +92,8 @@ var presets = []Preset{
 		Wavelength: 5.5e-12,
 		ScreenDist: 1.0,
 		SlitWidth:  1.0e-7,
-		U1:         1e-3, // Strong coupling → large η → significant visibility loss
+		U1:         1.2e-14, // η₀≈0.69, V≈0.31 — significant visibility loss
+		Mass:       electronMass,
 	},
 }
 
@@ -121,6 +135,7 @@ type LabPhysicsEngine struct {
 	ScreenDist float64
 	SlitWidth  float64
 	U1         float64 // Quaternionic coupling energy (QBP). 0 = standard QM.
+	Mass       float64 // Particle mass (kg). Per-preset: electron or neutron.
 	rng        *rand.Rand
 }
 
@@ -133,6 +148,7 @@ func NewLabPhysicsEngine() *LabPhysicsEngine {
 		ScreenDist: p.ScreenDist,
 		SlitWidth:  p.SlitWidth,
 		U1:         p.U1,
+		Mass:       p.Mass,
 		rng:        rand.New(rand.NewSource(42)),
 	}
 }
@@ -158,10 +174,11 @@ func (e *LabPhysicsEngine) Eta() float64 {
 	// Initial quaternionic fraction at the slit barrier.
 	// Simplified model: η₀ scales with U₁ relative to kinetic energy.
 	// η₀ = U₁² / (E_kinetic² + U₁²) — smooth saturation at 1.
-	hbar := 1.0545718e-34          // ℏ (J·s)
-	mass := 9.1093837e-31          // electron mass (kg)
-	v := hbar / (mass * e.Wavelength * 1e10) // velocity from de Broglie (simplified)
-	eKinetic := 0.5 * mass * v * v
+	//
+	// De Broglie: λ = h/(m·v), so v = h/(m·λ), E_k = ½mv² = h²/(2mλ²).
+	h := 6.62607015e-34 // Planck's constant (J·s)
+	v := h / (e.Mass * e.Wavelength)
+	eKinetic := 0.5 * e.Mass * v * v
 	eta0 := e.U1 * e.U1 / (eKinetic*eKinetic + e.U1*e.U1)
 
 	// Decay during propagation: κ = |U₁| · d (simplified, mirrors Lean decayConstant)
@@ -210,14 +227,17 @@ func (e *LabPhysicsEngine) Intensity(x float64) float64 {
 }
 
 // SampleHitPosition draws a hit position from I(x) via rejection sampling.
+// Guarded: returns center (x=0) after 10 000 failed attempts to prevent
+// infinite loops when intensity is near-zero everywhere (degenerate params).
 func (e *LabPhysicsEngine) SampleHitPosition() float64 {
 	halfWidth := 5.0 * e.FringeSpacing()
-	for {
+	for i := 0; i < 10_000; i++ {
 		x := (e.rng.Float64()*2 - 1) * halfWidth
 		if e.rng.Float64() < e.Intensity(x) {
 			return x
 		}
 	}
+	return 0 // Safety fallback: center of pattern
 }
 
 // ApplyPreset sets all physics parameters from a named preset.
@@ -231,6 +251,7 @@ func (e *LabPhysicsEngine) ApplyPreset(id string) bool {
 	e.ScreenDist = p.ScreenDist
 	e.SlitWidth = p.SlitWidth
 	e.U1 = p.U1
+	e.Mass = p.Mass
 	return true
 }
 

--- a/src/bakeoff/kaiju/game/lab_physics.go
+++ b/src/bakeoff/kaiju/game/lab_physics.go
@@ -73,8 +73,8 @@ var presets = []Preset{
 		Mass:       electronMass,
 	},
 	// QBP test presets — non-zero U₁ demonstrates quaternionic effects.
-	// U₁ values calibrated against E_kinetic ≈ 8.0e-15 J (Tonomura-like electrons).
-	// η₀ = U₁²/(E_k² + U₁²): weak → η₀≈0.09, strong → η₀≈0.69.
+	// U₁ values calibrated against relativistic E_k ≈ 7.6e-15 J (Tonomura electrons).
+	// η₀ = U₁²/(E_k² + U₁²): weak → η₀≈0.09, strong → η₀≈0.68.
 	{
 		ID:         "qbp_weak",
 		Label:      "QBP: Weak coupling",
@@ -82,7 +82,7 @@ var presets = []Preset{
 		Wavelength: 5.5e-12,
 		ScreenDist: 1.0,
 		SlitWidth:  1.0e-7,
-		U1:         2.5e-15, // η₀≈0.09, V≈0.91 — subtle visibility reduction
+		U1:         2.4e-15, // η₀≈0.09, V≈0.91 — subtle visibility reduction
 		Mass:       electronMass,
 	},
 	{
@@ -92,7 +92,7 @@ var presets = []Preset{
 		Wavelength: 5.5e-12,
 		ScreenDist: 1.0,
 		SlitWidth:  1.0e-7,
-		U1:         1.2e-14, // η₀≈0.69, V≈0.31 — significant visibility loss
+		U1:         1.1e-14, // η₀≈0.68, V≈0.32 — significant visibility loss
 		Mass:       electronMass,
 	},
 }
@@ -175,13 +175,25 @@ func (e *LabPhysicsEngine) Eta() float64 {
 	// Simplified model: η₀ scales with U₁ relative to kinetic energy.
 	// η₀ = U₁² / (E_kinetic² + U₁²) — smooth saturation at 1.
 	//
-	// De Broglie: λ = h/(m·v), so v = h/(m·λ), E_k = ½mv² = h²/(2mλ²).
-	h := 6.62607015e-34 // Planck's constant (J·s)
-	v := h / (e.Mass * e.Wavelength)
-	eKinetic := 0.5 * e.Mass * v * v
+	// Relativistic kinetic energy from de Broglie momentum p = h/λ:
+	//   E_total = sqrt((pc)² + (mc²)²),  E_k = E_total - mc²
+	// Required because Bach/Tonomura electrons reach v ≈ 0.44c.
+	const (
+		h = 6.62607015e-34  // Planck's constant (J·s)
+		c = 299792458.0     // speed of light (m/s)
+	)
+	p := h / e.Wavelength              // momentum (kg·m/s)
+	mc2 := e.Mass * c * c              // rest energy (J)
+	eTotal := math.Sqrt(p*c*p*c + mc2*mc2)
+	eKinetic := eTotal - mc2
 	eta0 := e.U1 * e.U1 / (eKinetic*eKinetic + e.U1*e.U1)
 
-	// Decay during propagation: κ = |U₁| · d (simplified, mirrors Lean decayConstant)
+	// Decay during propagation: κ = |U₁| · d (simplified algebraic proxy,
+	// mirrors Lean decayConstant in DoubleSlit.lean §8).
+	// NOTE: κ has units [J·m], so exp(-κ·L) is not dimensionless in SI.
+	// The Lean proofs use abstract algebra without SI tracking. For all
+	// current presets exp(-κ·L) ≈ 1.0 (decay is negligible). A physically
+	// grounded decay model is tracked as future work.
 	kappa := QBPDecayConstant(math.Abs(e.U1), e.SlitSep)
 	eta := eta0 * math.Exp(-kappa*e.ScreenDist)
 

--- a/src/bakeoff/kaiju/game/monitor_text.go
+++ b/src/bakeoff/kaiju/game/monitor_text.go
@@ -141,44 +141,52 @@ func NewMonitorTextSystem(host *engine.Host) *MonitorTextSystem {
 	botCenterY := bottomEdgeY + screenH/2
 	topCenterY := bottomEdgeY + screenH + gap + screenH/2
 
-	lCenterX := float32(-0.40) // Left wing center
-	rCenterX := float32(0.40)  // Right wing center
+	lCenterX := float32(-0.65) // Left wing center
+	rCenterX := float32(0.65)  // Right wing center
 
-	// Text rendering parameters
-	fontSize := float32(0.04)
-	maxWidth := screenW * 0.9 // Slight inset from screen edge
+	// Text rendering parameters — smaller font, tighter inset to avoid bezel overflow
+	fontSize := float32(0.028)
+	maxWidth := screenW * 0.85
+
+	// Text anchor: upper-left of each screen as seen by the scientist.
+	// The parent entity is rotated 180° Y and rootScale = (-1,1,1), so
+	// text expands "right" in screen space = toward -X in world space.
+	// Anchor at (screenCenter + screenW/2 * 0.85, topEdge, textZ) places
+	// text at the left edge (scientist's view) flowing right and down.
+	marginX := screenW * 0.425 // Half-width with slight inset
+	marginY := screenH * 0.45  // Near top edge
 
 	mts := &MonitorTextSystem{host: host}
 
 	// Left-Top: experiment title + mode
 	mts.leftTop = NewMonitorTextBlock(host,
 		matrix.NewVec3(
-			matrix.Float(lCenterX),
-			matrix.Float(topCenterY),
+			matrix.Float(lCenterX+marginX),
+			matrix.Float(topCenterY+marginY),
 			matrix.Float(textZ)),
 		fontSize, maxWidth, labColIvory())
 
 	// Left-Bottom: V&V verdict + QBP values (amber for emphasis)
 	mts.leftBottom = NewMonitorTextBlock(host,
 		matrix.NewVec3(
-			matrix.Float(lCenterX),
-			matrix.Float(botCenterY),
+			matrix.Float(lCenterX+marginX),
+			matrix.Float(botCenterY+marginY),
 			matrix.Float(textZ)),
 		fontSize, maxWidth, labColAmber())
 
 	// Right-Top: stats (particle count, fringe contrast)
 	mts.rightTop = NewMonitorTextBlock(host,
 		matrix.NewVec3(
-			matrix.Float(rCenterX),
-			matrix.Float(topCenterY),
+			matrix.Float(rCenterX+marginX),
+			matrix.Float(topCenterY+marginY),
 			matrix.Float(textZ)),
 		fontSize, maxWidth, labColIvory())
 
 	// Right-Bottom: preset name + emission rate info
 	mts.rightBottom = NewMonitorTextBlock(host,
 		matrix.NewVec3(
-			matrix.Float(rCenterX),
-			matrix.Float(botCenterY),
+			matrix.Float(rCenterX+marginX),
+			matrix.Float(botCenterY+marginY),
 			matrix.Float(textZ)),
 		fontSize, maxWidth, labColIvory())
 

--- a/src/bakeoff/kaiju/game/monitor_text.go
+++ b/src/bakeoff/kaiju/game/monitor_text.go
@@ -93,7 +93,7 @@ func (mt *MonitorTextBlock) Flush() {
 		mt.maxWidth,      // max width before wrap (0 = no wrap)
 		mt.fgColor,       // foreground color
 		bgColor,          // background color
-		rendering.FontJustifyLeft,  // horizontal justify
+		rendering.FontJustifyCenter, // horizontal justify
 		rendering.FontBaselineTop,  // vertical baseline
 		rootScale,        // parent transform scale
 		true,             // instanced
@@ -144,49 +144,39 @@ func NewMonitorTextSystem(host *engine.Host) *MonitorTextSystem {
 	lCenterX := float32(-0.65) // Left wing center
 	rCenterX := float32(0.65)  // Right wing center
 
-	// Text rendering parameters — smaller font, tighter inset to avoid bezel overflow
+	// Text rendering parameters — smaller font for readability
 	fontSize := float32(0.028)
 	maxWidth := screenW * 0.85
 
-	// Text anchor: upper-left of each screen as seen by the scientist.
-	// The parent entity is rotated 180° Y and rootScale = (-1,1,1), so
-	// text expands "right" in screen space = toward -X in world space.
-	// Anchor at (screenCenter + screenW/2 * 0.85, topEdge, textZ) places
-	// text at the left edge (scientist's view) flowing right and down.
-	marginX := screenW * 0.425 // Half-width with slight inset
-	marginY := screenH * 0.45  // Near top edge
-
 	mts := &MonitorTextSystem{host: host}
 
-	// Left-Top: experiment title + mode
+	// Place each text block at the screen center. FontJustifyCenter
+	// keeps text centered on the monitor regardless of rotation/mirror.
 	mts.leftTop = NewMonitorTextBlock(host,
 		matrix.NewVec3(
-			matrix.Float(lCenterX+marginX),
-			matrix.Float(topCenterY+marginY),
+			matrix.Float(lCenterX),
+			matrix.Float(topCenterY),
 			matrix.Float(textZ)),
 		fontSize, maxWidth, labColIvory())
 
-	// Left-Bottom: V&V verdict + QBP values (amber for emphasis)
 	mts.leftBottom = NewMonitorTextBlock(host,
 		matrix.NewVec3(
-			matrix.Float(lCenterX+marginX),
-			matrix.Float(botCenterY+marginY),
+			matrix.Float(lCenterX),
+			matrix.Float(botCenterY),
 			matrix.Float(textZ)),
 		fontSize, maxWidth, labColAmber())
 
-	// Right-Top: stats (particle count, fringe contrast)
 	mts.rightTop = NewMonitorTextBlock(host,
 		matrix.NewVec3(
-			matrix.Float(rCenterX+marginX),
-			matrix.Float(topCenterY+marginY),
+			matrix.Float(rCenterX),
+			matrix.Float(topCenterY),
 			matrix.Float(textZ)),
 		fontSize, maxWidth, labColIvory())
 
-	// Right-Bottom: preset name + emission rate info
 	mts.rightBottom = NewMonitorTextBlock(host,
 		matrix.NewVec3(
-			matrix.Float(rCenterX+marginX),
-			matrix.Float(botCenterY+marginY),
+			matrix.Float(rCenterX),
+			matrix.Float(botCenterY),
 			matrix.Float(textZ)),
 		fontSize, maxWidth, labColIvory())
 

--- a/src/bakeoff/kaiju/game/monitor_text.go
+++ b/src/bakeoff/kaiju/game/monitor_text.go
@@ -1,0 +1,204 @@
+//go:build !editor
+
+// monitor_text.go — 3D SDF text rendering on virtual lab monitor surfaces.
+//
+// Each of the 4 desk monitors shows text content (experiment info, stats,
+// verdict, etc.) using dirty-flag updates: text only re-renders when
+// content actually changes.
+
+package main
+
+import (
+	"kaiju/engine"
+	"kaiju/matrix"
+	"kaiju/rendering"
+	"math"
+)
+
+// ---------------------------------------------------------------------------
+// MonitorTextBlock — a single monitor's text overlay
+// ---------------------------------------------------------------------------
+
+// MonitorTextBlock manages SDF text rendering for one monitor surface.
+// It tracks the last-rendered string and only rebuilds geometry when the
+// content actually changes (dirty-flag pattern).
+type MonitorTextBlock struct {
+	host     *engine.Host
+	entity   *engine.Entity // Parent entity positioned at monitor location
+	drawings []rendering.Drawing
+	lastText string
+	dirty    bool
+	position matrix.Vec3
+	fontSize float32
+	maxWidth float32
+	fgColor  matrix.Color
+}
+
+// NewMonitorTextBlock creates a text block anchored at the given world
+// position (the center of a monitor's XY slab face).
+func NewMonitorTextBlock(host *engine.Host, position matrix.Vec3, fontSize, maxWidth float32, fgColor matrix.Color) *MonitorTextBlock {
+	return &MonitorTextBlock{
+		host:     host,
+		position: position,
+		fontSize: fontSize,
+		maxWidth: maxWidth,
+		fgColor:  fgColor,
+	}
+}
+
+// SetText updates the text to render. If the text is identical to the
+// last-rendered string, this is a no-op (dirty flag stays false).
+func (mt *MonitorTextBlock) SetText(text string) {
+	if text == mt.lastText {
+		return
+	}
+	mt.lastText = text
+	mt.dirty = true
+}
+
+// Flush rebuilds the SDF text geometry if (and only if) the content has
+// changed since the last Flush. Old text is hidden by deactivating its
+// parent entity; a new entity + drawing set is created for the updated
+// string.
+func (mt *MonitorTextBlock) Flush() {
+	if !mt.dirty {
+		return
+	}
+	mt.dirty = false
+
+	// Hide old text by deactivating the previous parent entity.
+	// Child drawings inherit the parent's active state, so they
+	// disappear without needing per-drawing removal.
+	if mt.entity != nil {
+		mt.entity.SetActive(false)
+	}
+
+	// Create a fresh parent entity at the monitor position.
+	mt.entity = engine.NewEntity(mt.host.WorkGroup())
+	mt.entity.Transform.SetPosition(mt.position)
+	mt.entity.Transform.SetScale(matrix.NewVec3(1, 1, 1))
+	// Rotate 180° around Y so text quads face -Z (toward scientist).
+	mt.entity.Transform.SetRotation(matrix.NewVec3(0, matrix.Float(math.Pi), 0))
+
+	// Render SDF text meshes.
+	// rootScale mirrors X so text reads left-to-right after Y rotation.
+	bgColor := matrix.NewColor(0, 0, 0, 0) // Transparent background
+	rootScale := matrix.NewVec3(-1, 1, 1)   // Mirror X (combined with Y rotation = correct reading order)
+
+	mt.drawings = mt.host.FontCache().RenderMeshes(
+		mt.host,
+		mt.lastText,
+		0, 0, 0,         // x, y, z offset
+		mt.fontSize,      // scale
+		mt.maxWidth,      // max width before wrap (0 = no wrap)
+		mt.fgColor,       // foreground color
+		bgColor,          // background color
+		rendering.FontJustifyLeft,  // horizontal justify
+		rendering.FontBaselineTop,  // vertical baseline
+		rootScale,        // parent transform scale
+		true,             // instanced
+		true,             // is3D (world-space text)
+		rendering.FontRegular,      // font face
+		1.3,              // line height multiplier
+		&mt.host.Cameras.Primary,   // camera container for 3D text
+	)
+
+	// Attach every glyph drawing to the parent entity so they move
+	// together and can be deactivated as a group.
+	for i := range mt.drawings {
+		mt.drawings[i].Transform = &mt.entity.Transform
+	}
+	mt.host.Drawings.AddDrawings(mt.drawings)
+}
+
+// ---------------------------------------------------------------------------
+// MonitorTextSystem — manages all 4 desk monitors
+// ---------------------------------------------------------------------------
+
+// MonitorTextSystem owns the four MonitorTextBlocks that correspond to
+// the 2x2 monitor layout on the scientist's desk.
+type MonitorTextSystem struct {
+	host        *engine.Host
+	leftTop     *MonitorTextBlock // Experiment title + mode
+	leftBottom  *MonitorTextBlock // V&V verdict + QBP values
+	rightTop    *MonitorTextBlock // Stats (N, fringe contrast)
+	rightBottom *MonitorTextBlock // Preset + emission rate info
+}
+
+// NewMonitorTextSystem creates the four text blocks positioned at the
+// monitor surfaces defined in buildPlatform (lab_game.go).
+func NewMonitorTextSystem(host *engine.Host) *MonitorTextSystem {
+	// Match flat monitor geometry from buildPlatform (lab_game.go).
+	// Flat screens at monitorZ = deskZ + 0.4 = -5.1, facing -Z.
+	monitorZ := float32(deskZ + 0.4)
+	textZ := monitorZ - 0.02 // Slightly in front of screen surface
+
+	screenH := float32(0.35)
+	screenW := float32(0.50)
+	gap := float32(0.03)
+
+	bottomEdgeY := float32(camStartY - 0.05 - screenH - screenH/2)
+	botCenterY := bottomEdgeY + screenH/2
+	topCenterY := bottomEdgeY + screenH + gap + screenH/2
+
+	lCenterX := float32(-0.40) // Left wing center
+	rCenterX := float32(0.40)  // Right wing center
+
+	// Text rendering parameters
+	fontSize := float32(0.04)
+	maxWidth := screenW * 0.9 // Slight inset from screen edge
+
+	mts := &MonitorTextSystem{host: host}
+
+	// Left-Top: experiment title + mode
+	mts.leftTop = NewMonitorTextBlock(host,
+		matrix.NewVec3(
+			matrix.Float(lCenterX),
+			matrix.Float(topCenterY),
+			matrix.Float(textZ)),
+		fontSize, maxWidth, labColIvory())
+
+	// Left-Bottom: V&V verdict + QBP values (amber for emphasis)
+	mts.leftBottom = NewMonitorTextBlock(host,
+		matrix.NewVec3(
+			matrix.Float(lCenterX),
+			matrix.Float(botCenterY),
+			matrix.Float(textZ)),
+		fontSize, maxWidth, labColAmber())
+
+	// Right-Top: stats (particle count, fringe contrast)
+	mts.rightTop = NewMonitorTextBlock(host,
+		matrix.NewVec3(
+			matrix.Float(rCenterX),
+			matrix.Float(topCenterY),
+			matrix.Float(textZ)),
+		fontSize, maxWidth, labColIvory())
+
+	// Right-Bottom: preset name + emission rate info
+	mts.rightBottom = NewMonitorTextBlock(host,
+		matrix.NewVec3(
+			matrix.Float(rCenterX),
+			matrix.Float(botCenterY),
+			matrix.Float(textZ)),
+		fontSize, maxWidth, labColIvory())
+
+	return mts
+}
+
+// UpdateAll sets text on all four monitors. Each block only marks itself
+// dirty if its text actually changed, so unchanged monitors cost nothing.
+func (mts *MonitorTextSystem) UpdateAll(title, verdict, stats, info string) {
+	mts.leftTop.SetText(title)
+	mts.leftBottom.SetText(verdict)
+	mts.rightTop.SetText(stats)
+	mts.rightBottom.SetText(info)
+}
+
+// Flush is called once per frame. Only monitors whose text changed since
+// the last Flush will rebuild their SDF geometry.
+func (mts *MonitorTextSystem) Flush() {
+	mts.leftTop.Flush()
+	mts.leftBottom.Flush()
+	mts.rightTop.Flush()
+	mts.rightBottom.Flush()
+}

--- a/src/bakeoff/kaiju/game/monitor_text.go
+++ b/src/bakeoff/kaiju/game/monitor_text.go
@@ -1,134 +1,211 @@
 //go:build !editor
 
-// monitor_text.go — Screen-space UI panels for lab data display.
+// monitor_text.go — CPU-rasterized text on 3D monitor surfaces.
 //
-// Replaces the broken 3D SDF text approach with Kaiju's HTML/CSS UI system.
-// Four panels at screen corners show experiment info, verdict, stats, and
-// status — styled as translucent cockpit instruments over the 3D lab view.
+// Each of the 4 desk monitors displays text content by rasterizing it
+// into an RGBA image buffer, uploading as a GPU texture, and mapping
+// onto a flat quad mesh positioned at the monitor surface.
+// Dirty-flag updates: text only re-rasterizes when content changes.
 
 package main
 
 import (
+	"image"
+	"image/color"
+	"image/draw"
+	"math"
+	"strings"
+
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/basicfont"
+	"golang.org/x/image/math/fixed"
+
 	"kaiju/engine"
 	"kaiju/engine/assets"
-	"kaiju/engine/ui"
 	"kaiju/matrix"
+	"kaiju/registry/shader_data_registry"
 	"kaiju/rendering"
 )
 
+const (
+	monTexW = 512
+	monTexH = 256
+)
+
 // ---------------------------------------------------------------------------
-// MonitorTextBlock — one screen-space info panel
+// MonitorTextBlock — one monitor's text-on-texture display
 // ---------------------------------------------------------------------------
 
-// MonitorTextBlock manages a screen-space UI panel with a header label
-// and a content label. Text updates use a dirty-flag pattern — the label
-// only redraws when content actually changes.
+// MonitorTextBlock manages a textured quad on a monitor surface.
+// Text is CPU-rasterized into an RGBA buffer and uploaded to the GPU.
 type MonitorTextBlock struct {
-	header   *ui.Label
-	content  *ui.Label
+	host     *engine.Host
+	entity   *engine.Entity
+	texture  *rendering.Texture
 	lastText string
+	dirty    bool
+	position matrix.Vec3
+	quadW    float32    // World-space width of the text quad
+	quadH    float32    // World-space height
+	fgColor  color.RGBA // Text color for rasterization
 }
 
-// newMonitorTextBlock creates a panel with header and content labels.
-func newMonitorTextBlock(uiMgr *ui.Manager, tex *rendering.Texture,
-	x, y, w, h float32, headerText string, fgColor matrix.Color) *MonitorTextBlock {
+func newMonitorTextBlock(host *engine.Host, pos matrix.Vec3,
+	quadW, quadH float32, fg color.RGBA) *MonitorTextBlock {
 
-	// Background panel — dark translucent slate
-	panel := uiMgr.Add().ToPanel()
-	panel.Init(tex, ui.ElementTypePanel)
-	panel.DontFitContent()
-	panel.AllowClickThrough()
-	panel.SetColor(matrix.NewColor(0.05, 0.07, 0.12, 0.85))
-	panel.Base().Layout().SetPositioning(ui.PositioningAbsolute)
-	panel.Base().Layout().Scale(w, h)
-	panel.Base().Layout().SetOffset(x, y)
-	panel.Base().Layout().SetPadding(10, 8, 10, 8)
-
-	// Subtle border
-	bc := matrix.NewColor(0.25, 0.3, 0.4, 0.6)
-	panel.SetBorderSize(1, 1, 1, 1)
-	panel.SetBorderColor(bc, bc, bc, bc)
-
-	// Header label (small, amber)
-	header := uiMgr.Add().ToLabel()
-	header.Init(headerText)
-	header.SetColor(labColAmber())
-	header.SetBGColor(matrix.NewColor(0, 0, 0, 0))
-	header.SetFontSize(11)
-	panel.AddChild(header.Base())
-
-	// Content label
-	content := uiMgr.Add().ToLabel()
-	content.Init("")
-	content.SetColor(fgColor)
-	content.SetBGColor(matrix.NewColor(0, 0, 0, 0))
-	content.SetFontSize(14)
-	panel.AddChild(content.Base())
-
-	return &MonitorTextBlock{
-		header:  header,
-		content: content,
+	mt := &MonitorTextBlock{
+		host:     host,
+		position: pos,
+		quadW:    quadW,
+		quadH:    quadH,
+		fgColor:  fg,
 	}
+	mt.initQuad()
+	return mt
 }
 
-// SetText updates the content label. No-op if text hasn't changed.
+func (mt *MonitorTextBlock) initQuad() {
+	host := mt.host
+
+	// Rasterize blank initial texture (dark monitor "off" state)
+	blankImg := rasterizeMonitorText("", monTexW, monTexH, mt.fgColor)
+
+	// Create GPU texture from pixel data
+	var err error
+	mt.texture, err = rendering.NewTextureFromMemory(
+		rendering.GenerateUniqueTextureKey,
+		blankImg.Pix,
+		monTexW, monTexH,
+		rendering.TextureFilterLinear,
+	)
+	if err != nil {
+		return
+	}
+	mt.texture.DelayedCreate(host.Window.Renderer)
+
+	// Create quad mesh positioned at monitor surface
+	mesh := rendering.NewMeshQuad(host.MeshCache())
+	mt.entity = engine.NewEntity(host.WorkGroup())
+	mt.entity.Transform.SetPosition(mt.position)
+	mt.entity.Transform.SetScale(matrix.NewVec3(
+		matrix.Float(mt.quadW), matrix.Float(mt.quadH), 1))
+	// Rotate 180° around Y so quad faces -Z (toward scientist)
+	mt.entity.Transform.SetRotation(matrix.NewVec3(
+		0, matrix.Float(math.Pi), 0))
+
+	// Create textured material instance
+	baseMat, _ := host.MaterialCache().Material(assets.MaterialDefinitionUnlit)
+	mat := baseMat.CreateInstance([]*rendering.Texture{mt.texture})
+
+	sd := &shader_data_registry.ShaderDataUnlit{
+		ShaderDataBase: rendering.NewShaderDataBase(),
+		Color:          matrix.NewColor(1, 1, 1, 1), // No tint — texture colors only
+		UVs:            matrix.NewVec4(0, 0, 1, 1),
+	}
+
+	drawing := rendering.Drawing{
+		Material:   mat,
+		Mesh:       mesh,
+		Transform:  &mt.entity.Transform,
+		ShaderData: sd,
+		ViewCuller: &host.Cameras.Primary,
+	}
+	host.Drawings.AddDrawing(drawing)
+}
+
+// SetText updates the text to render. If the text is identical to the
+// last-rendered string, this is a no-op (dirty flag stays false).
 func (mt *MonitorTextBlock) SetText(text string) {
 	if text == mt.lastText {
 		return
 	}
 	mt.lastText = text
-	mt.content.SetText(text)
+	mt.dirty = true
+}
+
+// Flush re-rasterizes and uploads the texture if the text has changed.
+func (mt *MonitorTextBlock) Flush() {
+	if !mt.dirty || mt.texture == nil {
+		return
+	}
+	mt.dirty = false
+
+	img := rasterizeMonitorText(mt.lastText, monTexW, monTexH, mt.fgColor)
+
+	// Mirror horizontally to compensate for the pi Y-rotation
+	mirrorImageH(img)
+
+	mt.texture.WritePixels(mt.host.Window.Renderer, []rendering.GPUImageWriteRequest{
+		{
+			Region: matrix.Vec4i{0, 0, monTexW, monTexH},
+			Pixels: img.Pix,
+		},
+	})
 }
 
 // ---------------------------------------------------------------------------
-// MonitorTextSystem — manages the four cockpit-style info panels
+// MonitorTextSystem — manages all 4 desk monitors
 // ---------------------------------------------------------------------------
 
-// MonitorTextSystem owns the four MonitorTextBlocks positioned at the
-// screen corners, replacing the old 3D monitor text approach.
+// MonitorTextSystem owns the four MonitorTextBlocks that correspond to
+// the 2x2 monitor layout on the scientist's desk.
 type MonitorTextSystem struct {
+	host        *engine.Host
 	leftTop     *MonitorTextBlock // Experiment title + mode
 	leftBottom  *MonitorTextBlock // V&V verdict + QBP values
 	rightTop    *MonitorTextBlock // Stats (N, fringe contrast)
 	rightBottom *MonitorTextBlock // Preset + emission rate info
 }
 
-// NewMonitorTextSystem creates the four UI panels at screen corners.
-func NewMonitorTextSystem(uiMgr *ui.Manager, host *engine.Host) *MonitorTextSystem {
-	tex, _ := host.TextureCache().Texture(
-		assets.TextureSquare, rendering.TextureFilterLinear)
+// NewMonitorTextSystem creates the four textured quads positioned at
+// the monitor surfaces defined in buildPlatform (lab_game.go).
+func NewMonitorTextSystem(host *engine.Host) *MonitorTextSystem {
+	// Match flat monitor geometry from buildPlatform (lab_game.go).
+	// Flat screens at monitorZ = deskZ + 0.4, facing -Z.
+	monitorZ := float32(deskZ + 0.4)
+	textZ := monitorZ - 0.015 // Slightly in front of screen surface
 
-	w := float32(host.Window.Width())
+	screenH := float32(0.35)
+	screenW := float32(0.50)
+	gap := float32(0.03)
 
-	// Layout: two columns at screen edges
-	panelW := float32(260)
-	panelH := float32(80)
-	margin := float32(15)
-	gap := float32(8)
+	bottomEdgeY := float32(camStartY - 0.05 - screenH - screenH/2)
+	botCenterY := bottomEdgeY + screenH/2
+	topCenterY := bottomEdgeY + screenH + gap + screenH/2
 
-	mts := &MonitorTextSystem{}
+	lCenterX := float32(-0.65)
+	rCenterX := float32(0.65)
 
-	mts.leftTop = newMonitorTextBlock(uiMgr, tex,
-		margin, margin, panelW, panelH,
-		"EXPERIMENT", labColIvory())
+	// Quad slightly smaller than screen for bezel margin
+	quadW := screenW * 0.92
+	quadH := screenH * 0.92
 
-	mts.leftBottom = newMonitorTextBlock(uiMgr, tex,
-		margin, margin+panelH+gap, panelW, panelH,
-		"VERDICT", labColAmber())
+	ivory := color.RGBA{255, 250, 240, 255}
+	amber := color.RGBA{244, 162, 97, 255}
 
-	mts.rightTop = newMonitorTextBlock(uiMgr, tex,
-		w-margin-panelW, margin, panelW, panelH,
-		"STATISTICS", labColIvory())
+	mts := &MonitorTextSystem{host: host}
 
-	mts.rightBottom = newMonitorTextBlock(uiMgr, tex,
-		w-margin-panelW, margin+panelH+gap, panelW, panelH,
-		"STATUS", labColIvory())
+	mts.leftTop = newMonitorTextBlock(host,
+		matrix.NewVec3(matrix.Float(lCenterX), matrix.Float(topCenterY), matrix.Float(textZ)),
+		quadW, quadH, ivory)
+
+	mts.leftBottom = newMonitorTextBlock(host,
+		matrix.NewVec3(matrix.Float(lCenterX), matrix.Float(botCenterY), matrix.Float(textZ)),
+		quadW, quadH, amber)
+
+	mts.rightTop = newMonitorTextBlock(host,
+		matrix.NewVec3(matrix.Float(rCenterX), matrix.Float(topCenterY), matrix.Float(textZ)),
+		quadW, quadH, ivory)
+
+	mts.rightBottom = newMonitorTextBlock(host,
+		matrix.NewVec3(matrix.Float(rCenterX), matrix.Float(botCenterY), matrix.Float(textZ)),
+		quadW, quadH, ivory)
 
 	return mts
 }
 
-// UpdateAll sets text on all four panels. Each block only updates the
-// label if its text actually changed.
+// UpdateAll sets text on all four monitors. Each block only marks itself
+// dirty if its text actually changed, so unchanged monitors cost nothing.
 func (mts *MonitorTextSystem) UpdateAll(title, verdict, stats, info string) {
 	mts.leftTop.SetText(title)
 	mts.leftBottom.SetText(verdict)
@@ -136,6 +213,75 @@ func (mts *MonitorTextSystem) UpdateAll(title, verdict, stats, info string) {
 	mts.rightBottom.SetText(info)
 }
 
-// Flush is a no-op — UI labels update immediately via SetText.
-// Kept for API compatibility with the old 3D SDF approach.
-func (mts *MonitorTextSystem) Flush() {}
+// Flush is called once per frame. Only monitors whose text changed since
+// the last Flush will re-rasterize and upload their textures.
+func (mts *MonitorTextSystem) Flush() {
+	mts.leftTop.Flush()
+	mts.leftBottom.Flush()
+	mts.rightTop.Flush()
+	mts.rightBottom.Flush()
+}
+
+// ---------------------------------------------------------------------------
+// Text rasterization helpers
+// ---------------------------------------------------------------------------
+
+// rasterizeMonitorText renders multi-line text onto a dark RGBA buffer
+// using the built-in basicfont (7x13 monospace — terminal aesthetic).
+func rasterizeMonitorText(text string, width, height int, fg color.RGBA) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+
+	// Dark monitor background (near-black with slight blue tint)
+	bg := color.RGBA{10, 16, 26, 255}
+	draw.Draw(img, img.Bounds(), image.NewUniform(bg), image.Point{}, draw.Src)
+
+	if text == "" {
+		return img
+	}
+
+	face := basicfont.Face7x13
+
+	d := &font.Drawer{
+		Dst:  img,
+		Src:  image.NewUniform(fg),
+		Face: face,
+	}
+
+	marginX := 16
+	marginY := 22 // First baseline Y position
+	lineH := 22   // Pixels between baselines
+
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		y := marginY + i*lineH
+		if y > height-8 {
+			break // Don't draw past bottom
+		}
+		d.Dot = fixed.Point26_6{
+			X: fixed.Int26_6(marginX * 64),
+			Y: fixed.Int26_6(y * 64),
+		}
+		d.DrawString(line)
+	}
+
+	return img
+}
+
+// mirrorImageH flips an RGBA image horizontally in-place.
+// Needed because the quad is rotated pi around Y, which mirrors the texture.
+func mirrorImageH(img *image.RGBA) {
+	w := img.Bounds().Dx()
+	h := img.Bounds().Dy()
+	stride := img.Stride
+	for y := 0; y < h; y++ {
+		row := img.Pix[y*stride : y*stride+w*4]
+		for x := 0; x < w/2; x++ {
+			l := x * 4
+			r := (w - 1 - x) * 4
+			row[l], row[r] = row[r], row[l]
+			row[l+1], row[r+1] = row[r+1], row[l+1]
+			row[l+2], row[r+2] = row[r+2], row[l+2]
+			row[l+3], row[r+3] = row[r+3], row[l+3]
+		}
+	}
+}

--- a/src/bakeoff/kaiju/game/room.go
+++ b/src/bakeoff/kaiju/game/room.go
@@ -1,0 +1,22 @@
+//go:build !editor
+
+// Experiment Room Framework for QBP Virtual Lab
+//
+// Each experiment lives in a Room that owns its devices, physics, monitors,
+// and UI. Rooms are designed to be slotted into a hallway (future #393)
+// but for now are launched directly from the lab game.
+
+package main
+
+import "kaiju/engine"
+
+// ExperimentRoom is the interface that each experiment room implements.
+// The lab game delegates to the active room for setup, update, and teardown.
+type ExperimentRoom interface {
+	ID() string
+	DisplayName() string
+	Devices() []Device
+	Setup(host *engine.Host)
+	Update(dt float64)
+	Teardown()
+}

--- a/src/bakeoff/kaiju/game/ui_smoketest_game.go
+++ b/src/bakeoff/kaiju/game/ui_smoketest_game.go
@@ -1,0 +1,274 @@
+//go:build !editor
+
+// Kaiju UI Smoke Test — verifies slider, label, panel, and histogram rendering.
+//
+// Run with: QBP_UI_TEST=1 ./doubleslit
+// (Without QBP_UI_TEST=1, the normal double-slit game runs instead.)
+
+package main
+
+import (
+	"fmt"
+	"kaiju/engine"
+	"kaiju/engine/assets"
+	"kaiju/engine/ui"
+	"kaiju/matrix"
+	"kaiju/rendering"
+	"math"
+	"math/rand"
+	"os"
+	"reflect"
+)
+
+var uiSmokeTestMode = os.Getenv("QBP_UI_TEST") == "1"
+
+// ---------------------------------------------------------------------------
+// UI Smoke Test Game
+// ---------------------------------------------------------------------------
+
+type UISmokeTestGame struct {
+	host      *engine.Host
+	uiManager ui.Manager
+
+	// Widgets under test
+	slider     *ui.Slider
+	valueLabel *ui.Label
+	statsLabel *ui.Label
+	histBars   []*ui.Panel
+
+	// Simulated data
+	slitSepUm float64 // slit separation in micrometers
+	histogram [50]int
+	totalHits int
+	rng       *rand.Rand
+}
+
+func (g *UISmokeTestGame) PluginRegistry() []reflect.Type {
+	return []reflect.Type{}
+}
+
+func (g *UISmokeTestGame) ContentDatabase() (assets.Database, error) {
+	return assets.NewFileDatabase("content")
+}
+
+func (g *UISmokeTestGame) Launch(host *engine.Host) {
+	g.host = host
+	g.rng = rand.New(rand.NewSource(42))
+	g.slitSepUm = 1.0 // 1 um default
+
+	// Initialize UI manager
+	g.uiManager.Init(host)
+
+	// Get the square texture for panel backgrounds
+	tex, err := host.TextureCache().Texture(
+		assets.TextureSquare, rendering.TextureFilterLinear)
+	if err != nil {
+		fmt.Printf("Warning: could not load square texture: %v\n", err)
+	}
+
+	// ── Title Panel ─────────────────────────────────────────────
+	titlePanel := g.uiManager.Add().ToPanel()
+	titlePanel.Init(tex, ui.ElementTypePanel)
+	titlePanel.DontFitContent()
+	titlePanel.SetColor(matrix.NewColor(13.0/255, 27.0/255, 42.0/255, 0.95))
+	titlePanel.Base().Layout().SetPositioning(ui.PositioningAbsolute)
+	titlePanel.Base().Layout().Scale(400, 40)
+	titlePanel.Base().Layout().SetOffset(20, 10)
+	titlePanel.Base().Layout().SetPadding(10, 8, 10, 8)
+
+	titleLabel := g.uiManager.Add().ToLabel()
+	titleLabel.Init("Kaiju UI Smoke Test")
+	titleLabel.SetColor(matrix.NewColor(1, 215.0/255, 0, 1)) // Gold
+	titleLabel.SetBGColor(matrix.NewColor(0, 0, 0, 0))
+	titleLabel.SetFontSize(24)
+	titlePanel.AddChild(titleLabel.Base())
+
+	// ── BIG slider — root level, no parent panel ──────────────
+	g.slider = g.uiManager.Add().ToSlider()
+	g.slider.Init()
+	g.slider.Base().ToPanel().DontFitContent() // Prevent shrink-wrapping to bg/fg panels
+	g.slider.SetBGColor(matrix.NewColor(0.4, 0.4, 0.4, 1))
+	g.slider.SetFGColor(matrix.NewColor(1.0, 0.2, 0.2, 1)) // Bright red handle
+	g.slider.Base().Layout().Scale(600, 50)
+	g.slider.SetValueWithoutEvent(0.5)
+
+	// Value readout — must be inside a panel (labels need a parent panel)
+	valueLabelPanel := g.uiManager.Add().ToPanel()
+	valueLabelPanel.Init(tex, ui.ElementTypePanel)
+	valueLabelPanel.DontFitContent()
+	valueLabelPanel.AllowClickThrough()
+	valueLabelPanel.SetColor(matrix.NewColor(0, 0, 0, 0)) // Transparent
+	valueLabelPanel.Base().Layout().SetPositioning(ui.PositioningAbsolute)
+	valueLabelPanel.Base().Layout().Scale(650, 40)
+	valueLabelPanel.Base().Layout().SetOffset(20, 120)
+
+	g.valueLabel = g.uiManager.Add().ToLabel()
+	g.valueLabel.Init("d = 1.00 um  --  CLICK AND DRAG THE RED BAR ABOVE")
+	g.valueLabel.SetColor(matrix.NewColor(1, 1, 0, 1)) // Bright yellow
+	g.valueLabel.SetBGColor(matrix.NewColor(0, 0, 0, 0))
+	g.valueLabel.SetFontSize(22)
+	valueLabelPanel.AddChild(g.valueLabel.Base())
+
+	// Wire up slider change event
+	g.slider.Base().AddEvent(ui.EventTypeChange, func() {
+		val := g.slider.Value()
+		fmt.Printf("[SLIDER] value=%.3f\n", val)
+		// Log scale: 0.1 to 10 um
+		logMin := math.Log10(0.1)
+		logMax := math.Log10(10.0)
+		g.slitSepUm = math.Pow(10, logMin+float64(val)*(logMax-logMin))
+		g.valueLabel.SetText(fmt.Sprintf("d = %.2f um", g.slitSepUm))
+		// Reset histogram on change
+		g.histogram = [50]int{}
+		g.totalHits = 0
+	})
+
+	// Debug: log click events on the slider
+	g.slider.Base().AddEvent(ui.EventTypeDown, func() {
+		fmt.Println("[SLIDER] DOWN event received")
+	})
+	g.slider.Base().AddEvent(ui.EventTypeUp, func() {
+		fmt.Println("[SLIDER] UP event received")
+	})
+
+	// ── Stats Panel ─────────────────────────────────────────────
+	statsPanel := g.uiManager.Add().ToPanel()
+	statsPanel.Init(tex, ui.ElementTypePanel)
+	statsPanel.DontFitContent()
+	statsPanel.SetColor(matrix.NewColor(0.1, 0.12, 0.1, 0.9))
+	statsPanel.Base().Layout().SetPositioning(ui.PositioningAbsolute)
+	statsPanel.Base().Layout().Scale(400, 60)
+	statsPanel.Base().Layout().SetOffset(20, 190)
+	statsPanel.Base().Layout().SetPadding(15, 10, 15, 10)
+
+	g.statsLabel = g.uiManager.Add().ToLabel()
+	g.statsLabel.Init("N = 0 | Fringe: 50.0 um | COLLECTING...")
+	g.statsLabel.SetColor(matrix.NewColor(244.0/255, 162.0/255, 97.0/255, 1)) // Amber
+	g.statsLabel.SetBGColor(matrix.NewColor(0, 0, 0, 0))
+	g.statsLabel.SetFontSize(18)
+	statsPanel.AddChild(g.statsLabel.Base())
+
+	// ── Histogram Panel ─────────────────────────────────────────
+	histPanel := g.uiManager.Add().ToPanel()
+	histPanel.Init(tex, ui.ElementTypePanel)
+	histPanel.DontFitContent()
+	histPanel.SetColor(matrix.NewColor(0.08, 0.08, 0.08, 0.9))
+	histPanel.Base().Layout().SetPositioning(ui.PositioningAbsolute)
+	histPanel.Base().Layout().Scale(400, 220)
+	histPanel.Base().Layout().SetOffset(20, 260)
+	histPanel.Base().Layout().SetPadding(10, 25, 10, 10)
+
+	histTitle := g.uiManager.Add().ToLabel()
+	histTitle.Init("Hit Distribution")
+	histTitle.SetColor(matrix.NewColor(1, 1, 0.94, 1)) // Ivory
+	histTitle.SetBGColor(matrix.NewColor(0, 0, 0, 0))
+	histTitle.SetFontSize(14)
+	histPanel.AddChild(histTitle.Base())
+
+	// Create histogram bars (50 bars)
+	g.histBars = make([]*ui.Panel, 50)
+	for i := 0; i < 50; i++ {
+		bar := g.uiManager.Add().ToPanel()
+		bar.Init(tex, ui.ElementTypePanel)
+		bar.DontFitContent()
+		bar.SetColor(matrix.NewColor(212.0/255, 170.0/255, 90.0/255, 1)) // Ochre
+		bar.Base().Layout().SetPositioning(ui.PositioningAbsolute)
+		bar.Base().Layout().Scale(5, 1) // 5px wide, 1px tall initially
+		bar.Base().Layout().SetOffset(float32(i)*6.4+10, 165)
+		histPanel.AddChild(bar.Base())
+		g.histBars[i] = bar
+	}
+
+	// ── Border demo on the stats panel ──────────────────────────
+	statsPanel.SetBorderSize(1, 1, 1, 1)
+	statsPanel.SetBorderColor(
+		matrix.NewColor(212.0/255, 165.0/255, 116.0/255, 1),
+		matrix.NewColor(212.0/255, 165.0/255, 116.0/255, 1),
+		matrix.NewColor(212.0/255, 165.0/255, 116.0/255, 1),
+		matrix.NewColor(212.0/255, 165.0/255, 116.0/255, 1),
+	)
+
+	// Ensure cursor is visible and not locked
+	host.Window.ShowCursor()
+	host.Window.UnlockCursor()
+
+	// ── Update Loop ─────────────────────────────────────────────
+	host.Updater.AddUpdate(func(deltaTime float64) {
+		g.update(deltaTime)
+	})
+
+	fmt.Println("╔═══════════════════════════════════════════════╗")
+	fmt.Println("║  Kaiju UI Smoke Test                         ║")
+	fmt.Println("║  Drag slider to change slit separation       ║")
+	fmt.Println("║  Histogram updates in real-time              ║")
+	fmt.Println("║  ESC to quit                                 ║")
+	fmt.Println("╚═══════════════════════════════════════════════╝")
+}
+
+func (g *UISmokeTestGame) update(dt float64) {
+	// Emit ~100 particles per second
+	emitCount := int(100.0 * dt)
+	if emitCount < 1 {
+		emitCount = 1
+	}
+
+	d := g.slitSepUm * 1e-6 // convert to meters
+	wavelength := 5.0e-11
+	screenDist := 1.0
+	slitWidth := 1.0e-7
+	fringeSpacing := wavelength * screenDist / d
+	halfWidth := 5.0 * fringeSpacing
+
+	for i := 0; i < emitCount; i++ {
+		// Rejection sampling from Fraunhofer pattern
+		for {
+			x := (g.rng.Float64()*2 - 1) * halfWidth
+			argD := math.Pi * d * x / (wavelength * screenDist)
+			argA := math.Pi * slitWidth * x / (wavelength * screenDist)
+			cos2 := math.Cos(argD) * math.Cos(argD)
+			sinc2 := 1.0
+			if math.Abs(argA) > 1e-12 {
+				s := math.Sin(argA) / argA
+				sinc2 = s * s
+			}
+			if g.rng.Float64() < cos2*sinc2 {
+				// Bin it
+				t := (x/halfWidth + 1) / 2
+				bin := int(t * 50)
+				if bin < 0 {
+					bin = 0
+				}
+				if bin >= 50 {
+					bin = 49
+				}
+				g.histogram[bin]++
+				g.totalHits++
+				break
+			}
+		}
+	}
+
+	// Update histogram bars
+	maxBin := 1
+	for _, v := range g.histogram {
+		if v > maxBin {
+			maxBin = v
+		}
+	}
+	for i, bar := range g.histBars {
+		h := float32(g.histogram[i]) / float32(maxBin) * 150
+		if h < 1 {
+			h = 1
+		}
+		bar.Base().Layout().Scale(5, h)
+		bar.Base().Layout().SetOffsetY(165 - h)
+	}
+
+	// Update stats
+	verdict := "COLLECTING..."
+	if g.totalHits >= 1000 {
+		verdict = "PASS"
+	}
+	g.statsLabel.SetText(fmt.Sprintf("N = %d | Fringe: %.1f um | %s",
+		g.totalHits, fringeSpacing*1e6, verdict))
+}

--- a/src/bakeoff/kaiju/game/vv_checklist.go
+++ b/src/bakeoff/kaiju/game/vv_checklist.go
@@ -142,12 +142,12 @@ func (vc *VVChecklist) buildPanel(host *engine.Host) {
 		panelY+0.015,
 		matrix.Float(vc.panelCenterZ)-panelD/2+0.03))
 	titleEntity.Transform.SetScale(matrix.NewVec3(1, 1, 1))
-	// Text faces +Y (up from desk) — rotate -90° around X
+	// Text faces -Z (toward scientist) — rotate 180° around Y, rootScale (-1,1,1)
 	titleEntity.Transform.SetRotation(matrix.NewVec3(
-		matrix.Float(-math.Pi/2), 0, 0))
+		0, matrix.Float(math.Pi), 0))
 
 	bgColor := matrix.NewColor(0, 0, 0, 0)
-	rootScale := matrix.NewVec3(1, 1, 1)
+	rootScale := matrix.NewVec3(-1, 1, 1)
 
 	titleDrawings := host.FontCache().RenderMeshes(
 		host,
@@ -194,8 +194,9 @@ func (vc *VVChecklist) addItem(id, label string, checker func() CheckStatus) {
 	vc.nextItemIdx++
 
 	panelD := float32(0.30)
-	rowZ := vc.panelCenterZ - panelD/2 + 0.08 + float32(idx)*0.04
-	checkboxX := vc.panelCenterX - 0.20
+	// Rows stack in Z: first item nearest to monitor, last nearest to scientist
+	rowZ := vc.panelCenterZ - panelD/2 + 0.06 + float32(idx)*0.045
+	checkboxX := vc.panelCenterX - 0.18
 	checkboxY := float32(deskY) + 0.015
 
 	// Checkbox cube
@@ -203,7 +204,7 @@ func (vc *VVChecklist) addItem(id, label string, checker func() CheckStatus) {
 	entity := engine.NewEntity(host.WorkGroup())
 	entity.Transform.SetPosition(matrix.NewVec3(
 		matrix.Float(checkboxX), matrix.Float(checkboxY), matrix.Float(rowZ)))
-	entity.Transform.SetScale(matrix.NewVec3(0.018, 0.018, 0.018))
+	entity.Transform.SetScale(matrix.NewVec3(0.015, 0.015, 0.015))
 
 	mat, _ := host.MaterialCache().Material(assets.MaterialDefinitionUnlit)
 	sd := &shader_data_registry.ShaderDataUnlit{
@@ -220,33 +221,36 @@ func (vc *VVChecklist) addItem(id, label string, checker func() CheckStatus) {
 	}
 	host.Drawings.AddDrawing(drawing)
 
-	// AABB for raycast hit (generous for steep viewing angles)
+	// AABB for raycast hit
 	aabb := collision.AABB{
 		Center: matrix.NewVec3(matrix.Float(checkboxX), matrix.Float(checkboxY), matrix.Float(rowZ)),
 		Extent: matrix.NewVec3(0.02, 0.04, 0.02),
 	}
 
-	// Label text (3D SDF, lying on desk surface)
+	// Label: small 3D text standing up from desk, facing -Z (toward scientist)
+	// Same approach as monitor text — rotate pi around Y, rootScale (-1,1,1)
 	labelEntity := engine.NewEntity(host.WorkGroup())
 	labelEntity.Transform.SetPosition(matrix.NewVec3(
-		matrix.Float(checkboxX+0.03), matrix.Float(checkboxY+0.005), matrix.Float(rowZ)))
+		matrix.Float(checkboxX+0.03),
+		matrix.Float(checkboxY+0.005),
+		matrix.Float(rowZ)))
 	labelEntity.Transform.SetScale(matrix.NewVec3(1, 1, 1))
 	labelEntity.Transform.SetRotation(matrix.NewVec3(
-		matrix.Float(-math.Pi/2), 0, 0))
+		0, matrix.Float(math.Pi), 0))
 
 	bgColor := matrix.NewColor(0, 0, 0, 0)
-	rootScale := matrix.NewVec3(1, 1, 1)
+	rootScale := matrix.NewVec3(-1, 1, 1)
 
 	labelDrawings := host.FontCache().RenderMeshes(
 		host,
 		label,
 		0, 0, 0,
-		0.012,
-		0.35,
+		0.010,
+		0.30,
 		labColIvory(),
 		bgColor,
 		rendering.FontJustifyLeft,
-		rendering.FontBaselineTop,
+		rendering.FontBaselineBottom,
 		rootScale,
 		true,
 		true,

--- a/src/bakeoff/kaiju/game/vv_checklist.go
+++ b/src/bakeoff/kaiju/game/vv_checklist.go
@@ -1,0 +1,356 @@
+//go:build !editor
+
+// vv_checklist.go — Physical V&V checklist panel on the scientist's desk.
+//
+// NASA go/no-go style verification: auto-checked criteria (fringe spacing,
+// particle count, visibility) plus manual checkboxes the scientist clicks.
+// Traffic-light summary (GREEN/AMBER/RED) shows overall experiment status.
+
+package main
+
+import (
+	"kaiju/engine"
+	"kaiju/engine/assets"
+	"kaiju/engine/collision"
+	"kaiju/matrix"
+	"kaiju/platform/hid"
+	"kaiju/registry/shader_data_registry"
+	"kaiju/rendering"
+	"math"
+)
+
+// ---------------------------------------------------------------------------
+// Status types
+// ---------------------------------------------------------------------------
+
+type CheckStatus int
+
+const (
+	CheckPending CheckStatus = iota
+	CheckPass
+	CheckFail
+)
+
+// CheckStatusColor returns the NASA-standard color for a status.
+func CheckStatusColor(s CheckStatus) matrix.Color {
+	switch s {
+	case CheckPass:
+		return matrix.NewColor(0.2, 0.9, 0.3, 1) // GREEN
+	case CheckFail:
+		return matrix.NewColor(0.9, 0.1, 0.1, 1) // RED
+	default:
+		return matrix.NewColor(0.9, 0.7, 0.1, 1) // AMBER
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VVChecklistItem — one acceptance criterion
+// ---------------------------------------------------------------------------
+
+type VVChecklistItem struct {
+	ID        string
+	Label     string
+	Status    CheckStatus
+	AutoCheck func() CheckStatus // nil = manual (scientist clicks to toggle)
+
+	// 3D entities
+	checkboxEntity *engine.Entity
+	checkboxSD     *shader_data_registry.ShaderDataUnlit
+	aabb           collision.AABB
+}
+
+// ---------------------------------------------------------------------------
+// VVChecklist — the physical checklist panel
+// ---------------------------------------------------------------------------
+
+type VVChecklist struct {
+	host         *engine.Host
+	items        []*VVChecklistItem
+	summarySD    *shader_data_registry.ShaderDataUnlit
+	updateTimer  float64 // Throttle auto-checks to 2 Hz
+	panelCenterX float32
+	panelCenterZ float32
+	nextItemIdx  int // Tracks vertical stacking
+}
+
+// NewVVChecklist creates the V&V panel on the desk surface, centered in front
+// of the scientist's seated position.
+func NewVVChecklist(host *engine.Host) *VVChecklist {
+	vc := &VVChecklist{
+		host:         host,
+		panelCenterX: 0,
+		panelCenterZ: float32(deskZ) + 0.0, // Center of desk, front area
+	}
+	vc.buildPanel(host)
+	return vc
+}
+
+func (vc *VVChecklist) buildPanel(host *engine.Host) {
+	// Background panel — dark slate
+	panelW := matrix.Float(0.50)
+	panelD := matrix.Float(0.30)
+	panelY := matrix.Float(deskY + 0.005)
+
+	mesh := rendering.NewMeshCube(host.MeshCache())
+	entity := engine.NewEntity(host.WorkGroup())
+	entity.Transform.SetPosition(matrix.NewVec3(
+		matrix.Float(vc.panelCenterX), panelY, matrix.Float(vc.panelCenterZ)))
+	entity.Transform.SetScale(matrix.NewVec3(panelW, 0.005, panelD))
+
+	mat, _ := host.MaterialCache().Material(assets.MaterialDefinitionUnlit)
+	sd := &shader_data_registry.ShaderDataUnlit{
+		ShaderDataBase: rendering.NewShaderDataBase(),
+		Color:          matrix.NewColor(0.08, 0.10, 0.14, 1), // Dark slate
+		UVs:            matrix.NewVec4(0, 0, 1, 1),
+	}
+	drawing := rendering.Drawing{
+		Material:   mat,
+		Mesh:       mesh,
+		Transform:  &entity.Transform,
+		ShaderData: sd,
+		ViewCuller: &host.Cameras.Primary,
+	}
+	host.Drawings.AddDrawing(drawing)
+
+	// Traffic-light summary — cube at top of panel
+	lightEntity := engine.NewEntity(host.WorkGroup())
+	lightEntity.Transform.SetPosition(matrix.NewVec3(
+		matrix.Float(vc.panelCenterX-0.20),
+		panelY+0.02,
+		matrix.Float(vc.panelCenterZ)-panelD/2+0.03))
+	lightEntity.Transform.SetScale(matrix.NewVec3(0.03, 0.03, 0.03))
+
+	lightSD := &shader_data_registry.ShaderDataUnlit{
+		ShaderDataBase: rendering.NewShaderDataBase(),
+		Color:          CheckStatusColor(CheckPending),
+		UVs:            matrix.NewVec4(0, 0, 1, 1),
+	}
+	lightDrawing := rendering.Drawing{
+		Material:   mat,
+		Mesh:       mesh,
+		Transform:  &lightEntity.Transform,
+		ShaderData: lightSD,
+		ViewCuller: &host.Cameras.Primary,
+	}
+	host.Drawings.AddDrawing(lightDrawing)
+	vc.summarySD = lightSD
+
+	// Title text: "V&V CHECKLIST"
+	titleEntity := engine.NewEntity(host.WorkGroup())
+	titleEntity.Transform.SetPosition(matrix.NewVec3(
+		matrix.Float(vc.panelCenterX),
+		panelY+0.015,
+		matrix.Float(vc.panelCenterZ)-panelD/2+0.03))
+	titleEntity.Transform.SetScale(matrix.NewVec3(1, 1, 1))
+	// Text faces +Y (up from desk) — rotate -90° around X
+	titleEntity.Transform.SetRotation(matrix.NewVec3(
+		matrix.Float(-math.Pi/2), 0, 0))
+
+	bgColor := matrix.NewColor(0, 0, 0, 0)
+	rootScale := matrix.NewVec3(1, 1, 1)
+
+	titleDrawings := host.FontCache().RenderMeshes(
+		host,
+		"V&V CHECKLIST",
+		0, 0, 0,
+		0.018,
+		0,
+		labColIvory(),
+		bgColor,
+		rendering.FontJustifyCenter,
+		rendering.FontBaselineTop,
+		rootScale,
+		true,
+		true,
+		rendering.FontRegular,
+		0,
+		&host.Cameras.Primary,
+	)
+	for i := range titleDrawings {
+		titleDrawings[i].Transform = &titleEntity.Transform
+	}
+	host.Drawings.AddDrawings(titleDrawings)
+}
+
+// ---------------------------------------------------------------------------
+// Adding items
+// ---------------------------------------------------------------------------
+
+// AddAutoItem adds an auto-checked criterion. The checker function is called
+// periodically (2 Hz) and its return value determines the checkbox color.
+func (vc *VVChecklist) AddAutoItem(id, label string, checker func() CheckStatus) {
+	vc.addItem(id, label, checker)
+}
+
+// AddManualItem adds a manually-verified criterion. The scientist clicks the
+// checkbox to toggle between PENDING and PASS.
+func (vc *VVChecklist) AddManualItem(id, label string) {
+	vc.addItem(id, label, nil)
+}
+
+func (vc *VVChecklist) addItem(id, label string, checker func() CheckStatus) {
+	host := vc.host
+	idx := vc.nextItemIdx
+	vc.nextItemIdx++
+
+	panelD := float32(0.30)
+	rowZ := vc.panelCenterZ - panelD/2 + 0.08 + float32(idx)*0.04
+	checkboxX := vc.panelCenterX - 0.20
+	checkboxY := float32(deskY) + 0.015
+
+	// Checkbox cube
+	mesh := rendering.NewMeshCube(host.MeshCache())
+	entity := engine.NewEntity(host.WorkGroup())
+	entity.Transform.SetPosition(matrix.NewVec3(
+		matrix.Float(checkboxX), matrix.Float(checkboxY), matrix.Float(rowZ)))
+	entity.Transform.SetScale(matrix.NewVec3(0.018, 0.018, 0.018))
+
+	mat, _ := host.MaterialCache().Material(assets.MaterialDefinitionUnlit)
+	sd := &shader_data_registry.ShaderDataUnlit{
+		ShaderDataBase: rendering.NewShaderDataBase(),
+		Color:          CheckStatusColor(CheckPending),
+		UVs:            matrix.NewVec4(0, 0, 1, 1),
+	}
+	drawing := rendering.Drawing{
+		Material:   mat,
+		Mesh:       mesh,
+		Transform:  &entity.Transform,
+		ShaderData: sd,
+		ViewCuller: &host.Cameras.Primary,
+	}
+	host.Drawings.AddDrawing(drawing)
+
+	// AABB for raycast hit (generous for steep viewing angles)
+	aabb := collision.AABB{
+		Center: matrix.NewVec3(matrix.Float(checkboxX), matrix.Float(checkboxY), matrix.Float(rowZ)),
+		Extent: matrix.NewVec3(0.02, 0.04, 0.02),
+	}
+
+	// Label text (3D SDF, lying on desk surface)
+	labelEntity := engine.NewEntity(host.WorkGroup())
+	labelEntity.Transform.SetPosition(matrix.NewVec3(
+		matrix.Float(checkboxX+0.03), matrix.Float(checkboxY+0.005), matrix.Float(rowZ)))
+	labelEntity.Transform.SetScale(matrix.NewVec3(1, 1, 1))
+	labelEntity.Transform.SetRotation(matrix.NewVec3(
+		matrix.Float(-math.Pi/2), 0, 0))
+
+	bgColor := matrix.NewColor(0, 0, 0, 0)
+	rootScale := matrix.NewVec3(1, 1, 1)
+
+	labelDrawings := host.FontCache().RenderMeshes(
+		host,
+		label,
+		0, 0, 0,
+		0.012,
+		0.35,
+		labColIvory(),
+		bgColor,
+		rendering.FontJustifyLeft,
+		rendering.FontBaselineTop,
+		rootScale,
+		true,
+		true,
+		rendering.FontRegular,
+		0,
+		&host.Cameras.Primary,
+	)
+	for i := range labelDrawings {
+		labelDrawings[i].Transform = &labelEntity.Transform
+	}
+	host.Drawings.AddDrawings(labelDrawings)
+
+	item := &VVChecklistItem{
+		ID:             id,
+		Label:          label,
+		Status:         CheckPending,
+		AutoCheck:      checker,
+		checkboxEntity: entity,
+		checkboxSD:     sd,
+		aabb:           aabb,
+	}
+	vc.items = append(vc.items, item)
+}
+
+// ---------------------------------------------------------------------------
+// Per-frame update
+// ---------------------------------------------------------------------------
+
+// Update runs auto-checkers (throttled to 2 Hz) and handles manual checkbox
+// clicks via raycast.
+func (vc *VVChecklist) Update(host *engine.Host, dt float64) {
+	// Throttle auto-checks
+	vc.updateTimer += dt
+	if vc.updateTimer >= 0.5 {
+		vc.updateTimer = 0
+		for _, item := range vc.items {
+			if item.AutoCheck != nil {
+				newStatus := item.AutoCheck()
+				if newStatus != item.Status {
+					item.Status = newStatus
+					item.checkboxSD.Color = CheckStatusColor(newStatus)
+				}
+			}
+		}
+		vc.updateTrafficLight()
+	}
+
+	// Manual checkbox click via raycast
+	mouse := &host.Window.Mouse
+	if mouse.Pressed(hid.MouseButtonLeft) {
+		cam := host.PrimaryCamera()
+		w, h := host.Window.Width(), host.Window.Height()
+		screenCenter := matrix.NewVec2(float32(w)/2, float32(h)/2)
+		ray := cam.RayCast(screenCenter)
+
+		for _, item := range vc.items {
+			if item.AutoCheck != nil {
+				continue // Don't allow manual toggle on auto items
+			}
+			_, hit := item.aabb.RayHit(ray)
+			if hit {
+				// Toggle between PENDING and PASS
+				if item.Status == CheckPass {
+					item.Status = CheckPending
+				} else {
+					item.Status = CheckPass
+				}
+				item.checkboxSD.Color = CheckStatusColor(item.Status)
+				vc.updateTrafficLight()
+				break
+			}
+		}
+	}
+}
+
+func (vc *VVChecklist) updateTrafficLight() {
+	if vc.summarySD == nil {
+		return
+	}
+	vc.summarySD.Color = CheckStatusColor(vc.OverallStatus())
+}
+
+// OverallStatus returns the aggregate V&V status.
+func (vc *VVChecklist) OverallStatus() CheckStatus {
+	allPass := true
+	for _, item := range vc.items {
+		if item.Status == CheckFail {
+			return CheckFail
+		}
+		if item.Status != CheckPass {
+			allPass = false
+		}
+	}
+	if allPass && len(vc.items) > 0 {
+		return CheckPass
+	}
+	return CheckPending
+}
+
+// Reset clears all checklist items (used when switching presets).
+func (vc *VVChecklist) Reset() {
+	for _, item := range vc.items {
+		item.Status = CheckPending
+		item.checkboxSD.Color = CheckStatusColor(CheckPending)
+	}
+	vc.updateTrafficLight()
+}


### PR DESCRIPTION
## Summary

- **Full Kaiju-based virtual physics lab** for Experiment 03 (Double-Slit) — scientist sits at a desk with monitors, controls, and instruments
- **NASA/F-35 style control panel** with grouped buttons (Experiment, Parameters, Presets), color-coded by function
- **CPU-rasterized monitor text** on 3D surfaces (solved backface culling + frustum culling + alpha discard issues)
- **Particle cap system** (default 25K) with cycling, prevents FPS death spiral
- **V&V checklist** with auto-check criteria and manual verification items
- **Histogram monitor** showing real-time detector hit distribution
- **FPS camera** with WASD movement, mouse look, seated/standing positions

### Rendering fixes (latest commits)
- Custom `-Z` facing quad mesh (`newMeshQuadNegZ`) to solve backface culling — standard Kaiju quads face +Z, invisible from camera at Z=-6.5
- Custom `+Y` facing quad mesh (`newMeshQuadPosY`) for flat desk surface labels
- `alwaysVisibleCuller` to bypass frustum culling for zero-depth-AABB flat quads
- Opaque label backgrounds (alpha=1.0) to survive engine's 0.999 alpha discard threshold
- Increased text-to-monitor Z-offset (0.015m → 0.04m) to prevent Z-fighting

### Known issues (documented on #302)
- Text visibility from seated position needs James's visual verification after latest fixes
- GPU particle optimization deferred to #397 (research complete, plan posted)

### Also includes
- Facility design documents (Gemini-led: location, central hub, hallway, exterior)
- Paget persona (Lead Bio-Synthesist)
- Environmental conditions added to ground truth schema
- Oppenheimer strategic review #001

## Test plan

- [ ] Build: `cd src/bakeoff/kaiju/engine/src && go build -tags '!editor' -o ../../kaiju-ds .`
- [ ] Run: `VK_ICD_FILENAMES=/etc/vulkan/icd.d/amd_icd64.json QBP_LAB=1 LD_LIBRARY_PATH=../../local_libs ../../kaiju-ds`
- [ ] Press Q to sit — verify monitor text is readable from seated position
- [ ] Verify desk labels ("EXPERIMENT", "PARAMETERS", "PRESETS") visible on desk
- [ ] Click controls via crosshair — verify Start/Stop, Rate, Presets work
- [ ] Verify particle cap prevents FPS death spiral (stays >20 FPS at 25K)
- [ ] Verify histogram updates in real-time on right monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)