### PR TITLE
docs: SPRINT_STATUS — Pre-Sprint-4 Scoping (#408); Sprint 4 not on Lamb Shift

### DIFF
--- a/SPRINT_STATUS.md
+++ b/SPRINT_STATUS.md
@@ -10,7 +10,8 @@
 
 - **Active Sprint:** Sprint 3 (Experiment 03: Double-Slit)
 - **Lifecycle Stage:** Phase 5 (Publication) complete. Paper Task 3 section merged.
-- **Next Critical-Path Action:** Theory Refinement (#81) → Retrospective (#192)
+- **Next Critical-Path Action:** Theory Refinement (#81, Thread A in PR #407) → Retrospective (#192) → **Pre-Sprint-4 Strategic Scoping (#408)** → Sprint 4 (target TBD)
+- **Sprint 4 status:** **NOT committed to Lamb Shift.** Per Oppenheimer Resolution on PR #407 (R6, 2026-05-13) and Strategic Review #001 R3 (2026-02-15), the Lamb Shift's prerequisites (QBP Lagrangian, photon propagator, f(u) at hydrogen scale, renormalization scheme) are not in hand and the bound-state η-mechanism is not formulated. Oppenheimer recommendation: re-scope Sprint 4 toward quaternionic tensor product foundations + Bell's Theorem preparation. Final Sprint 4 scope decided by #408.
 
 > **Sprint 3 Phase 1 Complete:** PR #285 merged 2026-02-13 after 5 review rounds (10 total reviews). Full quaternionic dynamics with Adler decay. Empirical Anchor framework introduced. Issue #22 closed.
 


### PR DESCRIPTION
## Summary

Per Oppenheimer Resolution on PR #407 (R6, 2026-05-13), Sprint 4 is not committed to the Lamb Shift target. Updating SPRINT_STATUS critical path to reflect:

- **#408 (Pre-Sprint-4 Strategic Scoping)** inserted into the critical path after Sprint 3 Retrospective (#192)
- Sprint 4 status note: not on Lamb Shift; Oppenheimer recommendation is to re-scope toward tensor-product / Bell preparation; final scope decided by #408

## Why now

PR #407's Round 1 Oppenheimer resolution surfaced that Lamb Shift's prerequisites are not in hand:
1. No QBP Lagrangian for any system
2. No QBP photon propagator
3. f(u) at hydrogen scale not computed
4. No renormalization scheme for quaternionic Hilbert space
5. (A4) No bound-state η-mechanism formulated

This re-affirms Strategic Review #001 R3 (2026-02-15) with concrete anchoring.

## Spawned issues (already open, listed in commit message for traceability)

- #408 — Pre-Sprint-4 Strategic Scoping: Lamb Shift vs Bell's Theorem priority decision
- #409 — Define the QBP coupling-in-bound-states mechanism
- #410 — BPM null tests (beam-reversal + noise-floor sweep)
- #411 — Derive V = 1 − η_d without incoherent-averaging assumption

🤖 Generated with [Claude Code](https://claude.com/claude-code)