### PR TITLE
ci(lint): Install system deps for manim transitive build

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install system dependencies (for manim transitive deps)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpango1.0-dev libcairo2-dev pkg-config ffmpeg
+
       - name: Install dependencies
         run: uv sync --extra dev
 


### PR DESCRIPTION
## Summary

Add the `apt-get install -y libpango1.0-dev libcairo2-dev pkg-config ffmpeg` step to `.github/workflows/lint.yml` before `uv sync --extra dev`. Without these system libraries, `manimpango` (a transitive dep of `manim`, which is in main project deps) fails to build, breaking the entire lint workflow.

## Why now

PR #418 surfaced this latent infra gap. The prior 5 PRs merged today (#413, #414, #415, #416, #417/#419) all touched only markdown/Lean, so the lint workflow path filter `paths: ['**.py']` never fired. PR #418 added `scripts/cth_inventory_diff.py` — first .py file in this session — triggering lint, exposing the broken Install dependencies step.

## Fix

Identical to `.github/workflows/ci.yml` lines 24-27 (`Install system dependencies (for manim)` step). Surgical, +5 lines.

## Test plan

- [ ] CI green on this PR (lint workflow runs on .yml change too)
- [ ] After merge: PR #418 auto-rebases and lint workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)