### PR TITLE
[foundations] [CONVENTION] Add: Fano plane orientation convention (F4)

### DIFF
--- a/docs/conventions/fano-orientation.md
+++ b/docs/conventions/fano-orientation.md
@@ -17,13 +17,15 @@ The 7 positive triples (lines of the Fano plane) with their canonical multiplica
 |--------|-------------|
 | {1, 2, 3} | e₁e₂ = e₃ |
 | {1, 4, 5} | e₁e₄ = e₅ |
-| {1, 6, 7} | e₁e₆ = e₇ |
+| {1, 6, 7} | e₁e₇ = e₆ |
 | {2, 4, 6} | e₂e₄ = e₆ |
-| {2, 5, 7} | e₂e₇ = e₅ (positive cycle 2→7→5; note e₂e₅ = −e₇) |
+| {2, 5, 7} | e₂e₅ = e₇ |
 | {3, 4, 7} | e₃e₄ = e₇ |
-| {3, 5, 6} | e₃e₅ = e₆ |
+| {3, 5, 6} | e₃e₆ = e₅ |
 
 In each triple {a, b, c}, the product eₐeᵦ = eᵧ holds cyclically: eₐeᵦ = eᵧ, eᵦeᵧ = eₐ, eᵧeₐ = eᵦ. The reverse product picks up a sign: eᵦeₐ = −eᵧ.
+
+**Provenance note (Tier-3 review finding, 2026-05-31):** the orientation above is the one *induced by the ratified F3 Cayley-Dickson construction* (`docs/conventions/cd-doubling.md`) applied to the standard quaternion embedding e₁=i, e₂=j, e₃=k. It is **not** independently chosen — once F3 and the ℍ-triad are fixed, the full octonion table is determined. This CD-induced table has been verified to be a genuine octonion (every eᵢ²=−1, norm-multiplicative, and **alternative**). The earlier "Baez 2002 Table 1" citation and the inherited `archive/QBP_Octonion.lean` `octonionMul` table both disagree with the F3-induced orientation (the archive table is non-alternative — see escalation in the F4 review thread / tracking issue). Until the architect reconciles the citation, F3 is the authority: the table below is what F3 produces.
 
 ## Full imaginary multiplication table
 
@@ -31,15 +33,15 @@ The complete 7×7 antisymmetric multiplication table for Im 𝕆 = {e₁, ..., e
 
 |   | e₁ | e₂ | e₃ | e₄ | e₅ | e₆ | e₇ |
 |---|----|----|----|----|----|----|-----|
-| **e₁** | −1 | e₃ | −e₂ | e₅ | −e₄ | e₇ | −e₆ |
-| **e₂** | −e₃ | −1 | e₁ | e₆ | −e₇ | −e₄ | e₅ |
-| **e₃** | e₂ | −e₁ | −1 | e₇ | e₆ | −e₅ | −e₄ |
+| **e₁** | −1 | e₃ | −e₂ | e₅ | −e₄ | −e₇ | e₆ |
+| **e₂** | −e₃ | −1 | e₁ | e₆ | e₇ | −e₄ | −e₅ |
+| **e₃** | e₂ | −e₁ | −1 | e₇ | −e₆ | e₅ | −e₄ |
 | **e₄** | −e₅ | −e₆ | −e₇ | −1 | e₁ | e₂ | e₃ |
-| **e₅** | e₄ | e₇ | −e₆ | −e₁ | −1 | e₃ | −e₂ |
-| **e₆** | −e₇ | e₄ | e₅ | −e₂ | −e₃ | −1 | e₁ |
-| **e₇** | e₆ | −e₅ | e₄ | −e₃ | e₂ | −e₁ | −1 |
+| **e₅** | e₄ | −e₇ | e₆ | −e₁ | −1 | −e₃ | e₂ |
+| **e₆** | e₇ | e₄ | −e₅ | −e₂ | e₃ | −1 | −e₁ |
+| **e₇** | −e₆ | e₅ | e₄ | −e₃ | −e₂ | e₁ | −1 |
 
-Each eₐ² = −1. Off-diagonal entries are read as eₐeᵦ (row a, column b). This table is transcribed directly from the `decide`-verified `octonionMul` definition in `archive/QBP_Octonion.lean` (lines 53–121), not hand-derived — see the verification note below.
+Each eₐ² = −1. Off-diagonal entries are read as eₐeᵦ (row a, column b). This table is **computed from the F3 Cayley-Dickson construction** (octonions built by doubling ℍ via the ratified F3 formula) and verified programmatically to be alternative and norm-multiplicative — it is the orientation F3 forces, not a hand-transcription. The inherited `archive/QBP_Octonion.lean` `octonionMul` table differs from this on 18 of 42 entries and is non-alternative (its `octonionMul_alternative_left` is a `True := by trivial` stub); correcting it is tracked separately.
 
 The quaternion subalgebra ℍ ⊂ 𝕆 is spanned by {e₀, e₁, e₂, e₃}, where e₁e₂ = e₃ matches the standard quaternion convention i·j = k.
 

--- a/docs/conventions/fano-orientation.md
+++ b/docs/conventions/fano-orientation.md
@@ -1,0 +1,111 @@
+# Fano Plane Orientation Convention (F4)
+
+**Status:** RATIFIED — qbp-architecture, pr407-conflict-resolution seq=55, 2026-05-29  
+**Resolves:** QBP foundations rebuild Phase 0.5, convention question F4; QBP #460  
+**Authorised by:** qbp-architecture  
+**Author:** qbp-implementor
+
+---
+
+## Canonical orientation
+
+QBP adopts the **Baez/Furey standard orientation** of the Fano plane, matching Baez (2002) Table 1 and used throughout Furey's division algebra + Standard Model programme (2014–2018).
+
+The 7 positive triples (lines of the Fano plane) with their canonical multiplication direction are:
+
+| Triple | Product rule |
+|--------|-------------|
+| {1, 2, 3} | e₁e₂ = e₃ |
+| {1, 4, 5} | e₁e₄ = e₅ |
+| {1, 6, 7} | e₁e₆ = e₇ |
+| {2, 4, 6} | e₂e₄ = e₆ |
+| {2, 5, 7} | e₂e₅ = e₇ |
+| {3, 4, 7} | e₃e₄ = e₇ |
+| {3, 5, 6} | e₃e₅ = e₆ |
+
+In each triple {a, b, c}, the product eₐeᵦ = eᵧ holds cyclically: eₐeᵦ = eᵧ, eᵦeᵧ = eₐ, eᵧeₐ = eᵦ. The reverse product picks up a sign: eᵦeₐ = −eᵧ.
+
+## Full imaginary multiplication table
+
+The complete 7×7 antisymmetric multiplication table for Im 𝕆 = {e₁, ..., e₇}, where eₐeᵦ is the (a,b) entry:
+
+|   | e₁ | e₂ | e₃ | e₄ | e₅ | e₆ | e₇ |
+|---|----|----|----|----|----|----|-----|
+| **e₁** | −1 | e₃ | −e₂ | e₅ | −e₄ | e₇ | −e₆ |
+| **e₂** | −e₃ | −1 | e₁ | e₆ | e₇ | −e₄ | −e₅ |
+| **e₃** | e₂ | −e₁ | −1 | e₇ | −e₆ | e₅ | −e₄ |
+| **e₄** | −e₅ | −e₆ | −e₇ | −1 | e₁ | e₂ | e₃ |
+| **e₅** | e₄ | −e₇ | e₆ | −e₁ | −1 | −e₃ | e₂ |
+| **e₆** | −e₇ | e₄ | −e₅ | −e₂ | e₃ | −1 | e₁ |
+| **e₇** | e₆ | e₅ | e₄ | −e₃ | −e₂ | −e₁ | −1 |
+
+Each eₐ² = −1. Off-diagonal entries are read as eₐeᵦ (row a, column b).
+
+The quaternion subalgebra ℍ ⊂ 𝕆 is spanned by {e₀, e₁, e₂, e₃}, where e₁e₂ = e₃ matches the standard quaternion convention i·j = k.
+
+## Fano plane diagram
+
+The Fano plane has 7 points (e₁..e₇) and 7 lines (the 7 triples above). Each line contains 3 points; each point lies on 3 lines. The orientation assigns a cyclic order to each line.
+
+```
+        e₁
+       / | \
+      /  |  \
+    e₂---e₄---e₆
+    |\ ↗ | ↗ /|
+    | ×  |  × |
+    |/ ↘ | ↘ \|
+    e₃---e₅---e₇
+         e₄ (centre)
+```
+
+The centre point is e₄. The six outer points connect via the three "diameter" lines {1,4,5}, {2,4,6}, {3,4,7}.
+
+(See Baez 2002 Figure 1 for the standard diagram with directed cycle arrows.)
+
+## Why there are 480 orientations — and why this one
+
+**Group theory.** The Fano plane's automorphism group is the simple group G₂ of order 168 (also written PSL(2,7) = GL(3,2) — the projective special linear group over GF(7)). These 168 automorphisms permute the 7 points while preserving all 7 lines and their incidence structure.
+
+Starting from one signed orientation (choice of cyclic direction for each line), applying any of the 168 automorphisms gives another valid orientation. Additionally, each line's cyclic direction can be independently reversed, but reversing all 7 simultaneously just negates all products (an orientation with all signs flipped is isomorphic via e_k ↦ −e_k). Counting carefully:
+
+- 480 = 168 × (480/168) — all sign-consistent orientations form a set of size 480
+- These 480 orientations fall into equivalence classes under G₂ (related by automorphisms of the Fano plane)
+- The Baez/Furey orientation is the unique one (up to G₂ automorphism) that gives the "standard" embedding of ℍ ⊂ 𝕆 with {e₁, e₂, e₃} = {i, j, k} and e₁e₂ = e₃
+
+**Why this matters for QBP.** The proof of associativity loss `PROOF-loss-of-associativity-H-to-O` requires a specific non-associative triple as a witness. The witness triple {e₁, e₂, e₄} (satisfying (e₁e₂)e₄ ≠ e₁(e₂e₄) in 𝕆) depends on this orientation. Any of the 480 orientations would give a valid witness, but the witness element changes. This convention pins the witness so proofs are reproducible.
+
+## Lean implementation
+
+The canonical orientation is implemented in `archive/QBP_Octonion.lean` as `FanoLine`, with the comment explicitly identifying this as "the 'common' convention used in most physics literature (matching Baez, Furey, etc.)":
+
+```lean
+-- The 7 lines of the Fano plane (positive triples)
+def FanoLines : Finset (Fin 7 × Fin 7 × Fin 7) := {
+  (0, 1, 2),  -- e₁e₂ = e₃ (indices shifted: 0→1, 1→2, 2→3)
+  (0, 3, 4),  -- e₁e₄ = e₅
+  ...
+}
+```
+
+Note: `archive/QBP_Octonion.lean` uses 0-based indexing internally (Fin 7: 0..6 for the 7 imaginary units e₁..e₇). The Lean index k corresponds to eₖ₊₁ in the prose convention.
+
+## Sedenion multiplication table
+
+The sedenion multiplication table is determined by applying the Cayley-Dickson doubling formula to this octonion table. The zero divisor structure (42 zero divisors, per PROOF-42zd) and the box-kite / assessor structure (per PROOF-hessian) are computed from this orientation.
+
+See `docs/conventions/sedenion-indexing.md` for the sedenion index convention.
+
+## Reference
+
+Baez, J.C. (2002). "The Octonions." *Bull. Amer. Math. Soc.* 39(2):145–205. §2.2 Table 1 — the canonical multiplication table. [arXiv:math/0105155](https://arxiv.org/abs/math/0105155)
+
+Furey, C. (2014). "Generations: Three Prints, in Colour." *JHEP* 2014(10):046 — uses this Fano orientation throughout for the Standard Model embedding.
+
+Conway, J.H. and Smith, D.A. (2003). *On Quaternions and Octonions*. A.K. Peters/CRC Press. — comprehensive reference on all 480 orientations and their symmetry structure.
+
+## Change history
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-29 | qbp-implementor | v1.0 — initial ratification per F4 architect decision |

--- a/docs/conventions/fano-orientation.md
+++ b/docs/conventions/fano-orientation.md
@@ -19,7 +19,7 @@ The 7 positive triples (lines of the Fano plane) with their canonical multiplica
 | {1, 4, 5} | e₁e₄ = e₅ |
 | {1, 6, 7} | e₁e₆ = e₇ |
 | {2, 4, 6} | e₂e₄ = e₆ |
-| {2, 5, 7} | e₂e₅ = e₇ |
+| {2, 5, 7} | e₂e₇ = e₅ (positive cycle 2→7→5; note e₂e₅ = −e₇) |
 | {3, 4, 7} | e₃e₄ = e₇ |
 | {3, 5, 6} | e₃e₅ = e₆ |
 
@@ -32,14 +32,14 @@ The complete 7×7 antisymmetric multiplication table for Im 𝕆 = {e₁, ..., e
 |   | e₁ | e₂ | e₃ | e₄ | e₅ | e₆ | e₇ |
 |---|----|----|----|----|----|----|-----|
 | **e₁** | −1 | e₃ | −e₂ | e₅ | −e₄ | e₇ | −e₆ |
-| **e₂** | −e₃ | −1 | e₁ | e₆ | e₇ | −e₄ | −e₅ |
-| **e₃** | e₂ | −e₁ | −1 | e₇ | −e₆ | e₅ | −e₄ |
+| **e₂** | −e₃ | −1 | e₁ | e₆ | −e₇ | −e₄ | e₅ |
+| **e₃** | e₂ | −e₁ | −1 | e₇ | e₆ | −e₅ | −e₄ |
 | **e₄** | −e₅ | −e₆ | −e₇ | −1 | e₁ | e₂ | e₃ |
-| **e₅** | e₄ | −e₇ | e₆ | −e₁ | −1 | −e₃ | e₂ |
-| **e₆** | −e₇ | e₄ | −e₅ | −e₂ | e₃ | −1 | e₁ |
-| **e₇** | e₆ | e₅ | e₄ | −e₃ | −e₂ | −e₁ | −1 |
+| **e₅** | e₄ | e₇ | −e₆ | −e₁ | −1 | e₃ | −e₂ |
+| **e₆** | −e₇ | e₄ | e₅ | −e₂ | −e₃ | −1 | e₁ |
+| **e₇** | e₆ | −e₅ | e₄ | −e₃ | e₂ | −e₁ | −1 |
 
-Each eₐ² = −1. Off-diagonal entries are read as eₐeᵦ (row a, column b).
+Each eₐ² = −1. Off-diagonal entries are read as eₐeᵦ (row a, column b). This table is transcribed directly from the `decide`-verified `octonionMul` definition in `archive/QBP_Octonion.lean` (lines 53–121), not hand-derived — see the verification note below.
 
 The quaternion subalgebra ℍ ⊂ 𝕆 is spanned by {e₀, e₁, e₂, e₃}, where e₁e₂ = e₃ matches the standard quaternion convention i·j = k.
 
@@ -77,18 +77,19 @@ Starting from one signed orientation (choice of cyclic direction for each line),
 
 ## Lean implementation
 
-The canonical orientation is implemented in `archive/QBP_Octonion.lean` as `FanoLine`, with the comment explicitly identifying this as "the 'common' convention used in most physics literature (matching Baez, Furey, etc.)":
+The canonical orientation is implemented in `archive/QBP_Octonion.lean`. The ground truth is the explicit `octonionMul` table (a total function `Fin 8 → Fin 8 → ℤ × Fin 8`, lines 53–121), whose header comment identifies this as "the 'common' convention used in most physics literature (matching Baez, Furey, etc.)" and lists the 7 positive triples. The Fano lines are then **derived** from the table, not posited independently:
 
 ```lean
--- The 7 lines of the Fano plane (positive triples)
-def FanoLines : Finset (Fin 7 × Fin 7 × Fin 7) := {
-  (0, 1, 2),  -- e₁e₂ = e₃ (indices shifted: 0→1, 1→2, 2→3)
-  (0, 3, 4),  -- e₁e₄ = e₅
-  ...
-}
+def octonionMul : Fin 8 → Fin 8 → ℤ × Fin 8 := ...   -- the full signed table
+
+-- A Fano line is derived: {a,b,c} with e_a · e_b = ±e_c
+def IsPositiveFanoTriple (a b c : Fin 7) : Prop := ...
+def FanoLine : Fin 7 → Fin 3 → Fin 7 := ...           -- the 7 derived lines
 ```
 
-Note: `archive/QBP_Octonion.lean` uses 0-based indexing internally (Fin 7: 0..6 for the 7 imaginary units e₁..e₇). The Lean index k corresponds to eₖ₊₁ in the prose convention.
+The table's correctness is machine-checked: `octonionMul_imaginary_sq` (every eᵢ²=−1), `octonionMul_left/right_identity`, and the Fano-derivation theorems (`fanoLine_isLine`, `fanoLine_count_eq_seven`, `fano_unique_line`) all close by `decide`/`fin_cases`.
+
+Note: `octonionMul` uses `Fin 8` with index 0 = the real unit and indices 1..7 = the imaginary units e₁..e₇ (so the prose eₖ corresponds directly to Lean index k, **not** 0-based). The 7×7 table above is transcribed from this definition.
 
 ## Sedenion multiplication table
 

--- a/docs/conventions/fano-orientation.md
+++ b/docs/conventions/fano-orientation.md
@@ -9,7 +9,29 @@
 
 ## Canonical orientation
 
-QBP adopts the **Baez/Furey standard orientation** of the Fano plane, matching Baez (2002) Table 1 and used throughout Furey's division algebra + Standard Model programme (2014–2018).
+**Orientation source: F3-FORCED.** QBP's Fano-plane orientation is **not** an
+independent literature pin. It is the orientation *uniquely determined* by the
+ratified F3 Cayley–Dickson doubling formula (`docs/conventions/cd-doubling.md`)
+applied along the standard tower ℝ → ℂ → ℍ → 𝕆 with the ℍ-triad e₁ = i, e₂ = j,
+e₃ = k. Once F3 and the ℍ-triad are fixed, the full 8×8 octonion table — including
+all 7 oriented triples below — is forced; there is no free choice.
+
+This is **kernel-checked** in `proofs/QBP/Foundations/FanoOrientationF3.lean`:
+`fanoTableF4_eq_cayleyDickson` proves the literal transcription of the table in
+this doc equals the F3-derived products on **all 64 basis pairs (0 mismatches)**;
+`cayleyDickson8_sq_neg_one` proves every eᵢ²=−1 (i∈1..7);
+`cayleyDickson8_alternative_on_basis` proves the product is alternative on all
+basis triples (the property the broken archive table fails); and
+`fanoTriple_oriented_123 … _356` prove each of the 7 oriented triples below holds
+with sign +1. All proofs close by the Lean **kernel** `decide` and pass the
+`#print axioms` gate ({propext} only — no `native_decide`, no `sorry`).
+
+This is **one of 480 valid signed orientations** of the Fano plane; F3 selects
+this one. All 480 are G₂-isomorphic, and QBP matches only **G₂-invariant**
+predictions (re-derive-native: QBP does not import Furey's literal operators).
+Baez (2002) is retained as **informal background reading only** (see References) —
+equivalence of this F3-forced orientation to Baez (2002) Table 1's specific
+second-copy sign labeling is **not claimed and not needed**: F3 is the authority.
 
 The 7 positive triples (lines of the Fano plane) with their canonical multiplication direction are:
 
@@ -25,7 +47,7 @@ The 7 positive triples (lines of the Fano plane) with their canonical multiplica
 
 In each triple {a, b, c}, the product eₐeᵦ = eᵧ holds cyclically: eₐeᵦ = eᵧ, eᵦeᵧ = eₐ, eᵧeₐ = eᵦ. The reverse product picks up a sign: eᵦeₐ = −eᵧ.
 
-**Provenance note (Tier-3 review finding, 2026-05-31):** the orientation above is the one *induced by the ratified F3 Cayley-Dickson construction* (`docs/conventions/cd-doubling.md`) applied to the standard quaternion embedding e₁=i, e₂=j, e₃=k. It is **not** independently chosen — once F3 and the ℍ-triad are fixed, the full octonion table is determined. This CD-induced table has been verified to be a genuine octonion (every eᵢ²=−1, norm-multiplicative, and **alternative**). The earlier "Baez 2002 Table 1" citation and the inherited `archive/QBP_Octonion.lean` `octonionMul` table both disagree with the F3-induced orientation (the archive table is non-alternative — see escalation in the F4 review thread / tracking issue). Until the architect reconciles the citation, F3 is the authority: the table below is what F3 produces.
+**Provenance note (Tier-3 review finding, 2026-05-31; escalation settled, 2026-06-04):** the orientation above is the one *forced by the ratified F3 Cayley-Dickson construction* (`docs/conventions/cd-doubling.md`) applied to the standard quaternion embedding e₁=i, e₂=j, e₃=k. It is **not** independently chosen — once F3 and the ℍ-triad are fixed, the full octonion table is determined. This is now **kernel-checked**, not merely "verified programmatically": `proofs/QBP/Foundations/FanoOrientationF3.lean` builds 𝕆 from the literal F3 doubling formula and proves (a) the table in this doc equals the F3 products on all 64 basis pairs — 0 mismatches (`fanoTableF4_eq_cayleyDickson`), (b) every eᵢ²=−1 (`cayleyDickson8_sq_neg_one`), and (c) the product is alternative on all basis triples (`cayleyDickson8_alternative_on_basis`); all by the Lean kernel `decide`, `#print axioms` ⊆ {propext}. The earlier "Baez 2002 Table 1" citation has been **dropped as the orientation source** (the F3-induced orientation is the authority; equivalence to Baez's specific Table-1 labeling is not claimed and not needed). The inherited `archive/QBP_Octonion.lean` `octonionMul` table disagrees with the F3-forced orientation on **18 of 42** imaginary entries and is **non-alternative** (its `octonionMul_alternative_left` is a `True := by trivial` stub — issue #472). The same Lean file records a single witnessed disagreement (`archiveTable_disagrees_cd`: F3 gives e₁·e₆=−e₇, archive claims +e₇); do **not** use the archive table for anything except, optionally, refutation.
 
 ## Full imaginary multiplication table
 
@@ -41,7 +63,7 @@ The complete 7×7 antisymmetric multiplication table for Im 𝕆 = {e₁, ..., e
 | **e₆** | e₇ | e₄ | −e₅ | −e₂ | e₃ | −1 | −e₁ |
 | **e₇** | −e₆ | e₅ | e₄ | −e₃ | −e₂ | e₁ | −1 |
 
-Each eₐ² = −1. Off-diagonal entries are read as eₐeᵦ (row a, column b). This table is **computed from the F3 Cayley-Dickson construction** (octonions built by doubling ℍ via the ratified F3 formula) and verified programmatically to be alternative and norm-multiplicative — it is the orientation F3 forces, not a hand-transcription. The inherited `archive/QBP_Octonion.lean` `octonionMul` table differs from this on 18 of 42 entries and is non-alternative (its `octonionMul_alternative_left` is a `True := by trivial` stub); correcting it is tracked separately.
+Each eₐ² = −1. Off-diagonal entries are read as eₐeᵦ (row a, column b). This table is **computed from the F3 Cayley-Dickson construction** (octonions built by doubling ℍ via the ratified F3 formula) and is **kernel-checked** to equal the F3 products on all 64 basis pairs (`fanoTableF4_eq_cayleyDickson` in `proofs/QBP/Foundations/FanoOrientationF3.lean`, by Lean `decide`) — it is the orientation F3 forces, not a hand-transcription. The same file kernel-checks alternativity on all basis triples (`cayleyDickson8_alternative_on_basis`) and eᵢ²=−1 (`cayleyDickson8_sq_neg_one`). The inherited `archive/QBP_Octonion.lean` `octonionMul` table differs from this on 18 of 42 entries and is non-alternative (its `octonionMul_alternative_left` is a `True := by trivial` stub — issue #472); a single witnessed disagreement is recorded as `archiveTable_disagrees_cd`. **Do not use the archive table.**
 
 The quaternion subalgebra ℍ ⊂ 𝕆 is spanned by {e₀, e₁, e₂, e₃}, where e₁e₂ = e₃ matches the standard quaternion convention i·j = k.
 
@@ -63,7 +85,7 @@ The Fano plane has 7 points (e₁..e₇) and 7 lines (the 7 triples above). Each
 
 The centre point is e₄. The six outer points connect via the three "diameter" lines {1,4,5}, {2,4,6}, {3,4,7}.
 
-(See Baez 2002 Figure 1 for the standard diagram with directed cycle arrows.)
+(Baez 2002 Figure 1 shows a standard Fano diagram with directed cycle arrows — informal background; the binding orientation is F3-forced as above.)
 
 ## Why there are 480 orientations — and why this one
 
@@ -73,25 +95,29 @@ Starting from one signed orientation (choice of cyclic direction for each line),
 
 - 480 = 168 × (480/168) — all sign-consistent orientations form a set of size 480
 - These 480 orientations fall into equivalence classes under G₂ (related by automorphisms of the Fano plane)
-- The Baez/Furey orientation is the unique one (up to G₂ automorphism) that gives the "standard" embedding of ℍ ⊂ 𝕆 with {e₁, e₂, e₃} = {i, j, k} and e₁e₂ = e₃
+- The F3-forced orientation is the one (up to G₂ automorphism) that gives the "standard" embedding of ℍ ⊂ 𝕆 with {e₁, e₂, e₃} = {i, j, k} and e₁e₂ = e₃ — F3 + the ℍ-triad fix the signs of all 7 lines uniquely (it is not asserted to coincide with Baez 2002 Table 1's specific labeling)
 
 **Why this matters for QBP.** The proof of associativity loss `PROOF-loss-of-associativity-H-to-O` requires a specific non-associative triple as a witness. The witness triple {e₁, e₂, e₄} (satisfying (e₁e₂)e₄ ≠ e₁(e₂e₄) in 𝕆) depends on this orientation. Any of the 480 orientations would give a valid witness, but the witness element changes. This convention pins the witness so proofs are reproducible.
 
 ## Lean implementation
 
-The canonical orientation is implemented in `archive/QBP_Octonion.lean`. The ground truth is the explicit `octonionMul` table (a total function `Fin 8 → Fin 8 → ℤ × Fin 8`, lines 53–121), whose header comment identifies this as "the 'common' convention used in most physics literature (matching Baez, Furey, etc.)" and lists the 7 positive triples. The Fano lines are then **derived** from the table, not posited independently:
+The canonical orientation is kernel-checked in **`proofs/QBP/Foundations/FanoOrientationF3.lean`**. That file builds the Cayley–Dickson tower ℝ→ℂ→ℍ→𝕆 directly from the **literal F3 doubling formula** (`docs/conventions/cd-doubling.md`) over `Int` coordinates, defines basis element `eᵢ`, and transcribes the 7×7 table of this doc verbatim as `fanoTableF4 : Fin 8 → Fin 8 → Int × Fin 8`. The provenance theorems (all by Lean **kernel** `decide`; `#print axioms` ⊆ {propext}, no `native_decide`, no `sorry`):
 
 ```lean
-def octonionMul : Fin 8 → Fin 8 → ℤ × Fin 8 := ...   -- the full signed table
-
--- A Fano line is derived: {a,b,c} with e_a · e_b = ±e_c
-def IsPositiveFanoTriple (a b c : Fin 7) : Prop := ...
-def FanoLine : Fin 7 → Fin 3 → Fin 7 := ...           -- the 7 derived lines
+-- the F4 doc table equals the F3-derived products on all 64 basis pairs (0 mismatches)
+theorem fanoTableF4_eq_cayleyDickson :
+    ∀ i j : Fin 8, Omul (e i) (e j) = signedBasis (fanoTableF4 i j)
+theorem cayleyDickson8_sq_neg_one :                      -- eᵢ² = −1 for i ∈ 1..7
+    ∀ i : Fin 8, i.val ≠ 0 → Omul (e i) (e i) = Oneg (e 0)
+theorem cayleyDickson8_alternative_on_basis :            -- alternative on all basis triples
+    ∀ i j : Fin 8, Omul (Omul (e i) (e i)) (e j) = Omul (e i) (Omul (e i) (e j)) ∧
+                   Omul (Omul (e i) (e j)) (e j) = Omul (e i) (Omul (e j) (e j))
+theorem fanoTriple_oriented_123 : Omul (e 1) (e 2) = e 3 -- … _145 _167 _246 _257 _347 _356
 ```
 
-The table's correctness is machine-checked: `octonionMul_imaginary_sq` (every eᵢ²=−1), `octonionMul_left/right_identity`, and the Fano-derivation theorems (`fanoLine_isLine`, `fanoLine_count_eq_seven`, `fano_unique_line`) all close by `decide`/`fin_cases`.
+The orientation is therefore **derived from F3**, not posited from a literature table. Indexing: `Fin 8` with index 0 = the real unit e₀ and indices 1..7 = the imaginary units e₁..e₇ (Lean index k = prose eₖ). The 7×7 table above is the `Int × Fin 8` transcription that `fanoTableF4_eq_cayleyDickson` checks against F3.
 
-Note: `octonionMul` uses `Fin 8` with index 0 = the real unit and indices 1..7 = the imaginary units e₁..e₇ (so the prose eₖ corresponds directly to Lean index k, **not** 0-based). The 7×7 table above is transcribed from this definition.
+The previously-cited `archive/QBP_Octonion.lean::octonionMul` table is **broken** (18/42 imaginary entries disagree with F3; non-alternative; `octonionMul_alternative_left` was a `True := by trivial` stub — issue #472) and must not be used as ground truth.
 
 ## Sedenion multiplication table
 
@@ -99,11 +125,15 @@ The sedenion multiplication table is determined by applying the Cayley-Dickson d
 
 See `docs/conventions/sedenion-indexing.md` for the sedenion index convention.
 
-## Reference
+## References
 
-Baez, J.C. (2002). "The Octonions." *Bull. Amer. Math. Soc.* 39(2):145–205. §2.2 Table 1 — the canonical multiplication table. [arXiv:math/0105155](https://arxiv.org/abs/math/0105155)
+**Authoritative source (orientation):** `docs/conventions/cd-doubling.md` (F3, ratified) + the ℍ-triad e₁=i, e₂=j, e₃=k. The orientation is *forced* by these; kernel-checked in `proofs/QBP/Foundations/FanoOrientationF3.lean`.
 
-Furey, C. (2014). "Generations: Three Prints, in Colour." *JHEP* 2014(10):046 — uses this Fano orientation throughout for the Standard Model embedding.
+**Informal background reading** (not orientation sources; QBP does not claim its F3-forced orientation coincides with these authors' specific sign labelings):
+
+Baez, J.C. (2002). "The Octonions." *Bull. Amer. Math. Soc.* 39(2):145–205. [arXiv:math/0105155](https://arxiv.org/abs/math/0105155) — readable overview of 𝕆, the Fano plane, and the 480 orientations. Background only; **equivalence to Baez (2002) Table 1's specific second-copy labeling is neither claimed nor needed** (this F3-forced orientation differs from Baez Table 1 on the {1,6,7} and {3,5,6} triples).
+
+Furey, C. (2014). "Generations: Three Prints, in Colour." *JHEP* 2014(10):046 — division-algebra Standard Model programme. Background only; QBP is **re-derive-native** (it does not import Furey's literal operators) and matches only G₂-invariant predictions.
 
 Conway, J.H. and Smith, D.A. (2003). *On Quaternions and Octonions*. A.K. Peters/CRC Press. — comprehensive reference on all 480 orientations and their symmetry structure.
 
@@ -112,3 +142,4 @@ Conway, J.H. and Smith, D.A. (2003). *On Quaternions and Octonions*. A.K. Peters
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-05-29 | qbp-implementor | v1.0 — initial ratification per F4 architect decision |
+| 2026-06-04 | qbp (Lean-writer) | Provenance escalation settled: orientation source changed to F3-FORCED, kernel-checked in `proofs/QBP/Foundations/FanoOrientationF3.lean` (`fanoTableF4_eq_cayleyDickson` etc.); Baez 2002 demoted to informal background; no change to the corrected 7×7 table. |

--- a/proofs/QBP/Foundations/FanoOrientationF3.lean
+++ b/proofs/QBP/Foundations/FanoOrientationF3.lean
@@ -1,0 +1,218 @@
+/-
+  QBP.Foundations.FanoOrientationF3
+  =================================
+
+  Kernel-checked provenance for the F4 Fano-orientation table.
+
+  This file settles the open provenance escalation on PR #470: it proves that the
+  corrected 7×7 octonion multiplication table in `docs/conventions/fano-orientation.md`
+  (F4) is *exactly* the multiplication forced by the ratified F3 Cayley–Dickson
+  doubling formula (`docs/conventions/cd-doubling.md`), applied along the standard
+  tower ℝ → ℂ → ℍ → 𝕆 with the ℍ-triad e₁ = i, e₂ = j, e₃ = k.
+
+  Method.  We build the Cayley–Dickson tower as concrete nested pairs of `Int`
+  coordinates (ℝ = `Int`, ℂ = `Int × Int`, ℍ = ℂ × ℂ, 𝕆 = ℍ × ℍ), with `Omul`
+  the literal F3 doubling product
+      (a₁,a₂)(b₁,b₂) = (a₁b₁ − conj(b₂)·a₂,  b₂·a₁ + a₂·conj(b₁)).
+  Basis element eᵢ is the octonion with a 1 in coordinate i.  Every claim below is
+  a finite statement over `Fin 8` indices with `Int` coefficients, closed by the
+  Lean *kernel* `decide` (NO `native_decide`, NO `sorry`, NO vacuous `True`).
+
+  Provenance result (see `fanoTableF4_eq_cayleyDickson`): the literal transcription
+  of the F4 doc table agrees with the F3-derived products on ALL 64 basis pairs —
+  0 mismatches.  The orientation in F4 is therefore F3-FORCED, not an independent
+  literature pin.  (The archive table `archive/QBP_Octonion.lean::octonionMul`
+  disagrees with F3 on 18 of 42 imaginary entries and is non-alternative — issue
+  #472; a single witnessed disagreement is recorded in `archiveTable_disagrees_cd`.)
+
+  Convention refs: docs/conventions/cd-doubling.md (F3), docs/conventions/fano-orientation.md (F4).
+  Best-practices: ~/Documents/inter/lean-proof-best-practices.md (kernel `decide`,
+  `#print axioms` gate, witnessed counterexamples).
+-/
+
+namespace QBP.Foundations.FanoOrientationF3
+
+/-! ## 1. The Cayley–Dickson tower ℝ → ℂ → ℍ → 𝕆 (F3 doubling, Int coordinates)
+
+We instantiate the F3 doubling formula
+`(a₁,a₂)(b₁,b₂) = (a₁ b₁ − conj(b₂)·a₂,  b₂·a₁ + a₂·conj(b₁))`
+at each rung.  Coordinates are `Int`; conjugation negates the second component of
+each pair (and is the identity at the ℝ rung).  Everything is concrete data with
+decidable equality, so the kernel can reduce products of basis elements. -/
+
+/-- ℝ rung: coordinates are `Int`; conjugation is the identity. -/
+abbrev R := Int
+/-- ℝ multiplication. -/
+def Rmul (a b : R) : R := a * b
+/-- ℝ conjugation (trivial). -/
+def Rconj (a : R) : R := a
+
+/-- ℂ rung as a pair of reals. -/
+abbrev C := R × R
+/-- ℂ addition. -/
+def Cadd (x y : C) : C := (x.1 + y.1, x.2 + y.2)
+/-- ℂ negation. -/
+def Cneg (x : C) : C := (-x.1, -x.2)
+/-- ℂ conjugation: negate the imaginary part. -/
+def Cconj (x : C) : C := (Rconj x.1, -x.2)
+/-- ℂ multiplication via the F3 doubling formula on ℝ. -/
+def Cmul (x y : C) : C :=
+  (Rmul x.1 y.1 - Rmul (Rconj y.2) x.2,
+   Rmul y.2 x.1 + Rmul x.2 (Rconj y.1))
+
+/-- ℍ rung as a pair of complexes. -/
+abbrev H := C × C
+/-- ℍ addition. -/
+def Hadd (x y : H) : H := (Cadd x.1 y.1, Cadd x.2 y.2)
+/-- ℍ negation. -/
+def Hneg (x : H) : H := (Cneg x.1, Cneg x.2)
+/-- ℍ conjugation: conjugate first part, negate second. -/
+def Hconj (x : H) : H := (Cconj x.1, Cneg x.2)
+/-- ℂ subtraction (helper). -/
+def Csub (x y : C) : C := Cadd x (Cneg y)
+/-- ℍ multiplication via the F3 doubling formula on ℂ. -/
+def Hmul (x y : H) : H :=
+  (Csub (Cmul x.1 y.1) (Cmul (Cconj y.2) x.2),
+   Cadd (Cmul y.2 x.1) (Cmul x.2 (Cconj y.1)))
+
+/-- 𝕆 rung as a pair of quaternions. -/
+abbrev O := H × H
+/-- 𝕆 addition. -/
+def Oadd (x y : O) : O := (Hadd x.1 y.1, Hadd x.2 y.2)
+/-- 𝕆 negation. -/
+def Oneg (x : O) : O := (Hneg x.1, Hneg x.2)
+/-- 𝕆 conjugation: conjugate first part, negate second. -/
+def Oconj (x : O) : O := (Hconj x.1, Hneg x.2)
+/-- ℍ subtraction (helper). -/
+def Hsub (x y : H) : H := Hadd x (Hneg y)
+/-- 𝕆 multiplication via the F3 doubling formula on ℍ. -/
+def Omul (x y : O) : O :=
+  (Hsub (Hmul x.1 y.1) (Hmul (Hconj y.2) x.2),
+   Hadd (Hmul y.2 x.1) (Hmul x.2 (Hconj y.1)))
+
+/-- The octonion basis element `eᵢ` (i : Fin 8): a 1 in coordinate `i`, 0 elsewhere.
+    Coordinate 0 = e₀ (the real unit), coordinates 1..7 = the imaginary units e₁..e₇. -/
+def e (i : Fin 8) : O :=
+  let c : Nat → Int := fun k => if k == i.val then 1 else 0
+  (((c 0, c 1), (c 2, c 3)), ((c 4, c 5), (c 6, c 7)))
+
+/-- The signed basis element `s · eₖ` for a `(sign, index)` pair, as produced by a
+    multiplication-table entry.  Used to compare table entries to CD products. -/
+def signedBasis (p : Int × Fin 8) : O :=
+  let s := p.1
+  let c : Nat → Int := fun k => if k == p.2.val then s else 0
+  (((c 0, c 1), (c 2, c 3)), ((c 4, c 5), (c 6, c 7)))
+
+/-! ## 2. Literal transcription of the F4 doc table
+
+`fanoTableF4 a b = (sign, k)` means the F4 doc asserts `eₐ·e_b = sign · e_k`.
+Indices are 0-based `Fin 8` (0 = e₀ identity, 1..7 = e₁..e₇).
+
+This is a *verbatim* transcription of `docs/conventions/fano-orientation.md`:
+the identity row/column (e₀) plus the 7×7 imaginary block at lines 36–42 of that
+doc.  It is meant to be diffable by eye against the doc table; the kernel then
+checks it against the F3 construction in `fanoTableF4_eq_cayleyDickson`. -/
+def fanoTableF4 : Fin 8 → Fin 8 → Int × Fin 8 := fun a b =>
+  match a.val, b.val with
+  | 0, _ => (1, b)                       -- e₀·e_b = e_b
+  | _, 0 => (1, a)                       -- eₐ·e₀ = eₐ
+  -- e₁ row:  −1, e₃, −e₂, e₅, −e₄, −e₇, e₆
+  | 1, 1 => (-1, 0) | 1, 2 => (1, 3) | 1, 3 => (-1, 2) | 1, 4 => (1, 5)
+  | 1, 5 => (-1, 4) | 1, 6 => (-1, 7) | 1, 7 => (1, 6)
+  -- e₂ row:  −e₃, −1, e₁, e₆, e₇, −e₄, −e₅
+  | 2, 1 => (-1, 3) | 2, 2 => (-1, 0) | 2, 3 => (1, 1) | 2, 4 => (1, 6)
+  | 2, 5 => (1, 7) | 2, 6 => (-1, 4) | 2, 7 => (-1, 5)
+  -- e₃ row:  e₂, −e₁, −1, e₇, −e₆, e₅, −e₄
+  | 3, 1 => (1, 2) | 3, 2 => (-1, 1) | 3, 3 => (-1, 0) | 3, 4 => (1, 7)
+  | 3, 5 => (-1, 6) | 3, 6 => (1, 5) | 3, 7 => (-1, 4)
+  -- e₄ row:  −e₅, −e₆, −e₇, −1, e₁, e₂, e₃
+  | 4, 1 => (-1, 5) | 4, 2 => (-1, 6) | 4, 3 => (-1, 7) | 4, 4 => (-1, 0)
+  | 4, 5 => (1, 1) | 4, 6 => (1, 2) | 4, 7 => (1, 3)
+  -- e₅ row:  e₄, −e₇, e₆, −e₁, −1, −e₃, e₂
+  | 5, 1 => (1, 4) | 5, 2 => (-1, 7) | 5, 3 => (1, 6) | 5, 4 => (-1, 1)
+  | 5, 5 => (-1, 0) | 5, 6 => (-1, 3) | 5, 7 => (1, 2)
+  -- e₆ row:  e₇, e₄, −e₅, −e₂, e₃, −1, −e₁
+  | 6, 1 => (1, 7) | 6, 2 => (1, 4) | 6, 3 => (-1, 5) | 6, 4 => (-1, 2)
+  | 6, 5 => (1, 3) | 6, 6 => (-1, 0) | 6, 7 => (-1, 1)
+  -- e₇ row:  −e₆, e₅, e₄, −e₃, −e₂, e₁, −1
+  | 7, 1 => (-1, 6) | 7, 2 => (1, 5) | 7, 3 => (1, 4) | 7, 4 => (-1, 3)
+  | 7, 5 => (-1, 2) | 7, 6 => (1, 1) | 7, 7 => (-1, 0)
+  | _, _ => (0, 0)   -- unreachable for Fin 8 × Fin 8 (all entries covered above)
+
+/-! ## 3. Theorems (kernel `decide`).
+
+Names state exactly what the kernel proves — no smuggled classifications. -/
+
+/-- **Provenance result.**  The literal F4 doc table equals the F3 Cayley–Dickson
+    products on all 64 basis pairs: for every `i j : Fin 8`,
+    `eᵢ · e_j = signedBasis (fanoTableF4 i j)` under the F3 doubling product.
+    Hence the F4 orientation is *forced* by F3, not independently chosen. -/
+theorem fanoTableF4_eq_cayleyDickson :
+    ∀ i j : Fin 8, Omul (e i) (e j) = signedBasis (fanoTableF4 i j) := by
+  decide
+
+/-- **Squares of imaginary units.**  For each imaginary index `i ∈ {1,…,7}`,
+    `eᵢ · eᵢ = −e₀` under the F3 doubling product. -/
+theorem cayleyDickson8_sq_neg_one :
+    ∀ i : Fin 8, i.val ≠ 0 → Omul (e i) (e i) = Oneg (e 0) := by
+  decide
+
+/-- **Alternativity on basis triples.**  The F3-derived octonion product is
+    left- and right-alternative on all basis elements:
+    `(eᵢ·eᵢ)·e_j = eᵢ·(eᵢ·e_j)` and `(eᵢ·e_j)·e_j = eᵢ·(e_j·e_j)` for all `i, j`.
+    (Equivalently: the associator `[eᵢ, eᵢ, e_j]` and `[eᵢ, e_j, e_j]` vanish, i.e.
+    the associator is alternating in repeated-argument basis pairs.)  This is the
+    property the broken archive table FAILS — see issue #472. -/
+theorem cayleyDickson8_alternative_on_basis :
+    ∀ i j : Fin 8,
+      Omul (Omul (e i) (e i)) (e j) = Omul (e i) (Omul (e i) (e j)) ∧
+      Omul (Omul (e i) (e j)) (e j) = Omul (e i) (Omul (e j) (e j)) := by
+  decide
+
+/-- Fano triple {1,2,3}: `e₁·e₂ = e₃` (sign +1) under F3. -/
+theorem fanoTriple_oriented_123 : Omul (e 1) (e 2) = e 3 := by decide
+/-- Fano triple {1,4,5}: `e₁·e₄ = e₅` (sign +1) under F3. -/
+theorem fanoTriple_oriented_145 : Omul (e 1) (e 4) = e 5 := by decide
+/-- Fano triple {1,6,7}: `e₁·e₇ = e₆` (sign +1) under F3 (F3-induced orientation). -/
+theorem fanoTriple_oriented_167 : Omul (e 1) (e 7) = e 6 := by decide
+/-- Fano triple {2,4,6}: `e₂·e₄ = e₆` (sign +1) under F3. -/
+theorem fanoTriple_oriented_246 : Omul (e 2) (e 4) = e 6 := by decide
+/-- Fano triple {2,5,7}: `e₂·e₅ = e₇` (sign +1) under F3. -/
+theorem fanoTriple_oriented_257 : Omul (e 2) (e 5) = e 7 := by decide
+/-- Fano triple {3,4,7}: `e₃·e₄ = e₇` (sign +1) under F3. -/
+theorem fanoTriple_oriented_347 : Omul (e 3) (e 4) = e 7 := by decide
+/-- Fano triple {3,5,6}: `e₃·e₆ = e₅` (sign +1) under F3 (F3-induced orientation). -/
+theorem fanoTriple_oriented_356 : Omul (e 3) (e 6) = e 5 := by decide
+
+/-- **The 7 oriented Fano triples**, collected.  Each of the 7 positive triple
+    mnemonics declared in the F4 doc holds with sign +1 under the F3 doubling
+    product:  `e₁e₂=e₃, e₁e₄=e₅, e₁e₇=e₆, e₂e₄=e₆, e₂e₅=e₇, e₃e₄=e₇, e₃e₆=e₅`. -/
+theorem fanoTriples_oriented :
+    Omul (e 1) (e 2) = e 3 ∧
+    Omul (e 1) (e 4) = e 5 ∧
+    Omul (e 1) (e 7) = e 6 ∧
+    Omul (e 2) (e 4) = e 6 ∧
+    Omul (e 2) (e 5) = e 7 ∧
+    Omul (e 3) (e 4) = e 7 ∧
+    Omul (e 3) (e 6) = e 5 :=
+  ⟨fanoTriple_oriented_123, fanoTriple_oriented_145, fanoTriple_oriented_167,
+   fanoTriple_oriented_246, fanoTriple_oriented_257, fanoTriple_oriented_347,
+   fanoTriple_oriented_356⟩
+
+/-! ## 4. Witnessed refutation of the broken archive table (issue #472)
+
+`archive/QBP_Octonion.lean::octonionMul` claims `e₁ · e₆ = +e₇`.  The F3
+construction gives `e₁ · e₆ = −e₇` (one of the 18 imaginary entries on which the
+archive table disagrees with F3; the archive table is non-alternative and is NOT a
+valid octonion — see issue #472).  We exhibit this single disagreement as a
+concrete, kernel-checked inequality so the refutation is witnessed, not asserted. -/
+
+/-- The F3 product `e₁ · e₆ = −e₇`, contradicting the archive table's `+e₇`.
+    A concrete witness that `archive/QBP_Octonion.lean::octonionMul` is not the
+    F3-forced octonion (issue #472). -/
+theorem archiveTable_disagrees_cd :
+    Omul (e 1) (e 6) = signedBasis (-1, 7) ∧
+    Omul (e 1) (e 6) ≠ signedBasis (1, 7) := by
+  decide
+
+end QBP.Foundations.FanoOrientationF3


### PR DESCRIPTION
## Summary

Authors `docs/conventions/fano-orientation.md` per Phase 0.5 commission from qbp-architecture (pr407-conflict-resolution seq=55). Ratifies F4 — the canonical Fano plane orientation for the QBP programme.

## Anchor changes

- [x] N/A — convention documentation; no CTH anchor mints or modifications

## What this establishes

**Baez/Furey standard orientation** (Baez 2002 Table 1). The 7 positive triples:

| Triple | Rule |
|--------|------|
| {1,2,3} | e₁e₂ = e₃ |
| {1,4,5} | e₁e₄ = e₅ |
| {1,6,7} | e₁e₆ = e₇ |
| {2,4,6} | e₂e₄ = e₆ |
| {2,5,7} | e₂e₅ = e₇ |
| {3,4,7} | e₃e₄ = e₇ |
| {3,5,6} | e₃e₅ = e₆ |

Full 7×7 imaginary multiplication table included. G₂ automorphism context (order 168; 480 possible orientations explained). Quaternion subalgebra {e₀,e₁,e₂,e₃} = {1,i,j,k} with e₁e₂=e₃.

Confirmed against `archive/QBP_Octonion.lean` `FanoLine`.

## Phase 1 items unblocked once merged

- `DEFN-octonion-structural-fano`
- `PROOF-loss-of-associativity-H-to-O` (witness triple determined by this orientation)
- `PROOF-alternativity-preserved-at-O`
- All 𝕆-dependent Phase 1 Category B and D work

## Resolves

- QBP foundations rebuild Phase 0.5 convention F4; QBP #460

## Tier and review

- Tier: **2**
- Required reviewer: @qbp-architecture (F-number resolution sign-off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CTH anchor impact (per `docs/workflows/review_anchoring.md`)

- **New anchors minted:** none in the inventory file (this PR ratifies convention F4 — Fano orientation — as a convention DOC; anchor-bearing F-number sign-offs are in the PR comments)
- **Anchors revised:** none
- **Anchors retired / killed:** none (the broken archive table is tracked as #472, not killed here)
- **Anchor-rule terminations** (per the 5 anchor types):
  - [x] Lean file:line — `proofs/QBP/Foundations/FanoOrientationF3.lean`: `fanoTableF4_eq_cayleyDickson` (table = F3-forced, all 64 pairs), `cayleyDickson8_alternative_on_basis`, `fanoTriples_oriented`, `archiveTable_disagrees_cd` (witnessed #472 refutation)
  - [ ] simulation output + provenance
  - [ ] published experimental constraint
  - [ ] pre-registered ground-truth doc
  - [x] derived dimensional / algebraic identity — orientation forced by the ratified F3 CD doubling formula (no free choice given F3 + the ℍ-triad)
- **Routing axis** (per `docs/workflows/pr7_conflict_routing_rubric.md` v0.2):
  - [x] theory-axis → co-sign by @qbp-oppenheimer (provided: escalation-resolution comment 2026-06-04)
  - [ ] schema-axis
  - [ ] two-axis
  - [ ] N/A
