### PR TITLE
[foundations] #489: bump Mathlib v4.30.0-rc2 → v4.30.0 stable (first cadence bump)

### DIFF
--- a/proofs/QBP/Experiments/DoubleSlit.lean
+++ b/proofs/QBP/Experiments/DoubleSlit.lean
@@ -68,7 +68,9 @@ complex numbers by conjugation: j·z = z*·j where z* is complex conjugation. -/
 theorem qJ_sq : qJ * qJ = -(1 : Q) := by
   unfold qJ
   ext <;> simp [Quaternion.re_mul, Quaternion.imI_mul,
-                Quaternion.imJ_mul, Quaternion.imK_mul]
+                Quaternion.imJ_mul, Quaternion.imK_mul,
+                Quaternion.re_one, Quaternion.imI_one,
+                Quaternion.imJ_one, Quaternion.imK_one]
 
 /-- j times a complex quaternion z = ⟨a, b, 0, 0⟩ gives ⟨0, 0, a, -b⟩.
     This is the quaternion representation of: j·z = z*·j

--- a/proofs/lakefile.lean
+++ b/proofs/lakefile.lean
@@ -4,12 +4,15 @@ open Lake DSL
 -- Mathlib pin (foundations rebuild Phase 0, housekeeping item §2 in discovery
 -- response action items): pinned to the SHA already resolved in
 -- proofs/lake-manifest.json so `lake update` is reproducible across machines.
--- This SHA corresponds to Mathlib at a state compatible with toolchain
--- `leanprover/lean4:v4.30.0-rc2` (see proofs/lean-toolchain). To bump:
--- 1. update this @ "<sha>" to a known-good Mathlib commit on the same
---    Lean major version, 2. run `lake update`, 3. verify zero-sorry rebuild.
+-- This SHA is the Mathlib `v4.30.0` STABLE release tag, compatible with toolchain
+-- `leanprover/lean4:v4.30.0` (see proofs/lean-toolchain). Bumped off the
+-- superseded `v4.30.0-rc2` per the version-cadence policy (#489): pin to stable
+-- tags, never RCs. To bump:
+-- 1. update this @ "<sha>" to a known-good Mathlib STABLE tag (per #489 cadence),
+--    2. run `lake update`, 3. `lake exe cache get`, 4. verify zero-sorry rebuild
+--    + `#print axioms` audit before merge.
 require mathlib from git
-  "https://github.com/leanprover-community/mathlib4.git" @ "215c5f44e65f6e8431452880ebf0d433a3c00747"
+  "https://github.com/leanprover-community/mathlib4.git" @ "c5ea00351c28e24afc9f0f84379aa41082b1188f"
 
 package «QBPProofs» where
   -- Package configuration
@@ -19,7 +22,7 @@ lean_lib «QBP» where
   roots := #[`QBP]
 
 -- Sprint 12 inherited Lean corpus (folded from archive/lean-project/ per #81 PR8).
--- These files were authored on toolchain v4.18.0; this Lake project is v4.30.0-rc2.
+-- These files were authored on toolchain v4.18.0; this Lake project is v4.30.0.
 -- Toolchain migration is the work — see paper/Sprint12-Inherited-Reconciliation.md.
 -- Original package: «qbp»; renamed to «QBPSprint12» to avoid collision with «QBP» above.
 lean_lib «QBPSprint12» where

--- a/proofs/lean-toolchain
+++ b/proofs/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.30.0-rc2
+leanprover/lean4:v4.30.0


### PR DESCRIPTION
## Summary

First application of the **version-cadence policy (#489)**: move QBP off the *superseded release candidate* `v4.30.0-rc2` to the finalized **`v4.30.0` stable** tag. Per the policy: pin to stable tags, never RCs; bump is a deliberate PR gated on the zero-sorry rebuild.

## Changes
- `lean-toolchain`: `v4.30.0-rc2` → `v4.30.0`
- `lakefile.lean`: Mathlib pin `215c5f44` → `c5ea0035` (the v4.30.0 stable tag) + bump-procedure comment updated to the cadence policy
- `proofs/QBP/Experiments/DoubleSlit.lean`: **migration fix** (see below)

## The bump caught a real breakage at the gate ✅ (the policy working as designed)
The rebuild surfaced one cross-version failure: `qJ_sq` (`j² = −1`) at DoubleSlit.lean:68. Under v4.30.0 stable, Mathlib's `Quaternion` One-component lemmas (`re_one`/`imI_one`/…) became `@[scoped simp]` rather than global `@[simp]`, so the literal `1` in `-(1:Q)` no longer auto-reduced (the `Neg` lemmas are still global, so `-1` was fine). Fix: add the four One-component lemmas to that one `simp` set. **1 of 7** `ext <;> simp` sites needed it (the only one with `1` on the RHS). Math unchanged; tactic-only; no stub, no weakening. Authored by the `lean-prover` subagent, verified independently.

## Rebuild gate (the policy's merge condition) — PASSED
- ✅ `lake build` **green — 2344 jobs**, full project (entire foundations tower + Mathlib on stable)
- ✅ `#print axioms` on qJ_sq / j_mul_complex / coupling_decomposition = `{propext, Classical.choice, Quot.sound}` only
- ✅ no `native_decide` / `sorry` / stubs introduced
- (`lake-manifest.json` regenerates from the pin and is gitignored — not committed)

## Why this matters
QBP was on a stale RC of a version that has since gone stable. This is the ideal low-risk first cadence bump (same Lean version, finalized tag), and it **narrows the QBP↔PhysLean toolchain skew** (PhysLean on v4.29.1) from RC-vs-stable to one-stable-apart — directly relevant to the #486/#490 differential-test bridge.

## CTH anchor impact
- [x] N/A — no CTH inventory (`*.json`) changes; toolchain/pin + one Lean migration fix.

Refs #489 (cadence policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)