### PR TITLE
[process] Evidence-first review: theory-element three-way headline + mechanical-evidence sections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/tier-2.md
+++ b/.github/PULL_REQUEST_TEMPLATE/tier-2.md
@@ -34,6 +34,17 @@ labels: tier-2-review
 - [ ] New tests added (if applicable)
 - [ ] Manual testing performed
 
+## Mechanical verification evidence (links, not assertions)
+
+<!-- Body claims are not evidence. Every applicable box needs a pointer a
+     reviewer can click; a claim without a link is treated as UNVERIFIED.
+     If this PR makes a quantitative physical claim, use the Tier-3 template
+     instead (theory-element headline required there). -->
+
+- [ ] Clean-checkout build/tests: <!-- CI run link -->
+- [ ] Gate scripts touched by this PR's paths: <!-- CI link -->
+- [ ] Differential oracle (if oracle-relevant paths touched): PASS / FAIL+table / N-A: <!-- link -->
+
 ## CTH anchor impact (per `docs/workflows/review_anchoring.md`)
 
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE/tier-3.md
+++ b/.github/PULL_REQUEST_TEMPLATE/tier-3.md
@@ -19,11 +19,14 @@ labels: tier-3-review
      UNITS RULE (enforced): ALL quantities in every pillar are stated in QBP
      canonical format. Conversions happen ONCE at ingestion via QBP/Units
      (Constants / ScaleFactors / gen_test_vectors) and the conversion is LINKED.
-     Hand-converted or mixed-unit rows are a review-blocking defect — unit
-     mismatch is a historically human-caught error class; exclude it
-     structurally. -->
+     Dimensionless or natively-canonical quantities (probabilities, ratios,
+     visibilities): write "no conversion required — dimensionless" on the
+     provenance line rather than leaving it blank. Hand-converted or
+     mixed-unit rows are a review-blocking defect — unit mismatch is a
+     historically human-caught error class; exclude it structurally. -->
 
 **Claim under test:** <!-- one sentence -->
+**Dataset choice (look-elsewhere guard):** <!-- cite the pre-registered ground-truth doc, or give a one-line justification why THIS dataset is the consensus ground truth — the author does not get to silently pick the friendliest data -->
 
 | Pillar | Value (QBP canonical units) | Evidence (link, not assertion) |
 |---|---|---|

--- a/.github/PULL_REQUEST_TEMPLATE/tier-3.md
+++ b/.github/PULL_REQUEST_TEMPLATE/tier-3.md
@@ -26,16 +26,16 @@ labels: tier-3-review
      historically human-caught error class; exclude it structurally. -->
 
 **Claim under test:** <!-- one sentence -->
-**Dataset choice (look-elsewhere guard):** <!-- cite the pre-registered ground-truth doc, or give a one-line justification why THIS dataset is the consensus ground truth — the author does not get to silently pick the friendliest data -->
+**Dataset choice (look-elsewhere guard):** <!-- cite the pre-registered ground-truth doc. REQUIRED for any verdict-grade claim — no free-text justification substitutes. Exploratory work without pre-registration must state "exploratory — no verdict claimed" and the Verdict line stays empty -->
 
-| Pillar | Value (QBP canonical units) | Evidence (link, not assertion) |
-|---|---|---|
-| **Experimental evidence** (ground truth) | value ± σ | dataset + supporting papers |
-| **1. QBP prediction** | value | Lean theorem / oracle run |
-| **2. PhysLean baseline** (QM/SM incumbent) | value | bridge derivation; if PhysLean cannot produce this number (its SM layer is structure-only), use a PUBLISHED SM prediction with citation and say so — never leave blank, never let QBP grade its own homework |
+| Pillar | Value (QBP canonical units) | Free params | Data status | Evidence (link, not assertion) |
+|---|---|---|---|---|
+| **Experimental evidence** (ground truth) | value ± σ | n/a | n/a | dataset + supporting papers |
+| **1. QBP prediction** | value | count tuned on THIS dataset | in-sample fit / out-of-sample prediction | Lean theorem / oracle run **with exact input fixture/config linked** (same premise standard as theorems — undocumented config is a smuggled premise) |
+| **2. PhysLean baseline** (QM/SM incumbent) | value | count | in-sample / out-of-sample | bridge derivation; if PhysLean cannot produce this number (its SM layer is structure-only), use a PUBLISHED SM prediction with citation and say so — never leave blank, never let QBP grade its own homework |
 
-**Verdict:** QBP closer / equal / farther than baseline w.r.t. experiment, by <Δ in σ or relative error>
-**Unit conversion provenance:** <!-- link to the QBP/Units conversion used -->
+**Verdict:** QBP closer / equal / farther than baseline w.r.t. experiment, by <Δ in σ or relative error> — **valid only with parameter counts disclosed; an in-sample fit may never be scored against an out-of-sample prediction without saying so** (a theory with more knobs can always sit closer; Δ without the Occam columns is not evidence)
+**Unit conversion provenance:** <!-- link to the QBP/Units conversion used. Dimensionless means genuinely unit-free (probabilities, ratios); natural/Planck-unit nondimensionalization (c=ħ=1) does NOT qualify — those quantities still convert via QBP/Units -->
 
 ## Mechanical verification evidence (links, not assertions)
 

--- a/.github/PULL_REQUEST_TEMPLATE/tier-3.md
+++ b/.github/PULL_REQUEST_TEMPLATE/tier-3.md
@@ -8,6 +8,42 @@ labels: tier-3-review
 
 <!-- What theoretical or architectural change does this PR introduce? -->
 
+## Theory-element headline: three-way evidence comparison
+
+<!-- REQUIRED for any PR introducing or modifying a theory element that makes a
+     quantitative claim. This is the program's critical-path question in table
+     form: is QBP more predictive of the evidence than the incumbent?
+     Delete this section ONLY for pure-infrastructure / pure-math PRs with no
+     physical claim (state why in Summary).
+
+     UNITS RULE (enforced): ALL quantities in every pillar are stated in QBP
+     canonical format. Conversions happen ONCE at ingestion via QBP/Units
+     (Constants / ScaleFactors / gen_test_vectors) and the conversion is LINKED.
+     Hand-converted or mixed-unit rows are a review-blocking defect — unit
+     mismatch is a historically human-caught error class; exclude it
+     structurally. -->
+
+**Claim under test:** <!-- one sentence -->
+
+| Pillar | Value (QBP canonical units) | Evidence (link, not assertion) |
+|---|---|---|
+| **Experimental evidence** (ground truth) | value ± σ | dataset + supporting papers |
+| **1. QBP prediction** | value | Lean theorem / oracle run |
+| **2. PhysLean baseline** (QM/SM incumbent) | value | bridge derivation; if PhysLean cannot produce this number (its SM layer is structure-only), use a PUBLISHED SM prediction with citation and say so — never leave blank, never let QBP grade its own homework |
+
+**Verdict:** QBP closer / equal / farther than baseline w.r.t. experiment, by <Δ in σ or relative error>
+**Unit conversion provenance:** <!-- link to the QBP/Units conversion used -->
+
+## Mechanical verification evidence (links, not assertions)
+
+<!-- Body claims are not evidence. Every box needs a pointer a reviewer can click.
+     A claim without a link is treated by reviewers as UNVERIFIED. -->
+
+- [ ] Clean-checkout build: <!-- CI run link — a green run from YOUR working dir does not count -->
+- [ ] Gate scripts (foundations ratchet / layer imports / anchor impact): <!-- CI link -->
+- [ ] Differential oracle (PhysLean↔QBP): PASS / FAIL+table / N-A: <!-- run output or link -->
+- [ ] `#print axioms` audit (Lean-bearing PRs): <!-- output location in file or CI log -->
+
 ## Type of Change
 
 - [ ] New axiom or postulate

--- a/docs/workflows/review_tiers.md
+++ b/docs/workflows/review_tiers.md
@@ -245,6 +245,16 @@ The anchoring rule's mirror image, applied to the PR **author's** claims:
    reviewers reading content could not).
 4. **AC items asserting numerical correctness cite the differential run**, not
    the author.
+5. **External-comparator rule (beekeeper-ratified 2026-06-04):** external
+   physics libraries (PhysLean/physlib or any successor) are **never premises,
+   only comparators**. No QBP theorem may import them or cite their theorems as
+   proof steps; they appear exclusively as the baseline pillar of the three-way
+   headline and in the differential harness, touching QBP only at the JSON
+   boundary. Mechanically backstopped: external libraries are absent from
+   QBP's lake manifest, so a smuggled import fails the build. Reviewers treat
+   any external-library citation inside a `proofs/` derivation as BLOCKING
+   epistemic smuggling. (Mirror sentence lands in `layer-architecture.md` §2
+   once PR #497 merges — tracked in the migration plan.)
 
 Precedent incidents (all 2026-06-04): PR #493 did not build from a clean
 checkout (missing root aggregator; both Tier-3 reviews read content only);

--- a/docs/workflows/review_tiers.md
+++ b/docs/workflows/review_tiers.md
@@ -223,6 +223,37 @@ For PRs that go through multiple review rounds, Gemini reviews use `session_id` 
 
 Every BLOCKING-class claim in a Tier 2+ review must terminate at a verifiable artifact: a Lean theorem at file:line, a simulation output with numerical value + source, a published experimental citation, a pre-registered ground-truth document, or a formally derived dimensional/algebraic identity. Reviews containing unanchored blocking claims are **returned to the reviewer** and not read on merits until re-anchored. Full rule + examples + return mechanic: see [`docs/workflows/review_anchoring.md`](review_anchoring.md). Precedent incident: PR #407 Round 1 (three reviewers each missed three one-line check failures).
 
+### Evidence-first discipline (standing rule, effective 2026-06-04)
+
+The anchoring rule's mirror image, applied to the PR **author's** claims:
+
+1. **Body claims are not evidence.** Before content review, the reviewer checks
+   each box in the PR's "Mechanical verification evidence" section against its
+   link. A claim without a link (or with a link to a dirty-working-dir run
+   rather than a clean-checkout CI run) is marked **UNVERIFIED** in the review
+   and the corresponding AC cannot be assessed PASS on the author's word.
+2. **The theory-element headline is a review object.** For Tier-3 theory PRs the
+   three-way comparison table (Experimental evidence | QBP | PhysLean baseline)
+   must be present, complete, and in **QBP canonical units with linked
+   conversion provenance**. Missing pillar, silently-blank baseline, or
+   mixed/hand-converted units = BLOCKING.
+3. **Differential-test rows are review objects.** When the PhysLean↔QBP
+   differential oracle reports FAIL or BOUNDARY rows, the review must reproduce
+   the table and classify each row: *physics discrepancy* / *rounding artifact*
+   / *fixture drift*. "The test ran" is not "the review consumed the test."
+   Precedent: the #492 1-ULP finding (differential run caught what three
+   reviewers reading content could not).
+4. **AC items asserting numerical correctness cite the differential run**, not
+   the author.
+
+Precedent incidents (all 2026-06-04): PR #493 did not build from a clean
+checkout (missing root aggregator; both Tier-3 reviews read content only);
+`LieAlgebraIso.lean` never compiled since authoring (caught by aggregator
+wiring, not review); #492 (caught by differential run, not review).
+
+**Rationalization-prevention addition:** "The PR body says the build is green"
+→ body claims are assertions; only a clean-checkout CI link is evidence.
+
 ### NON-BLOCKING (note but don't block)
 
 - Style suggestions (naming, formatting preferences)

--- a/docs/workflows/review_tiers.md
+++ b/docs/workflows/review_tiers.md
@@ -255,6 +255,13 @@ The anchoring rule's mirror image, applied to the PR **author's** claims:
    any external-library citation inside a `proofs/` derivation as BLOCKING
    epistemic smuggling. (Mirror sentence lands in `layer-architecture.md` §2
    once PR #497 merges — tracked in the migration plan.)
+6. **Truth-in-labelling extends to prose surfaces:** PR titles, commit
+   messages, and review summaries are held to the same standard as Lean
+   identifiers (layer-architecture §3.4) — they state what is established,
+   not what is hoped. An overclaiming title ("proves X" when the kernel
+   proves a weaker Y) is a reviewer-flagged BLOCKING finding: titles and
+   commit messages enter the immutable git log, where they outlive their
+   caveats.
 
 Precedent incidents (all 2026-06-04): PR #493 did not build from a clean
 checkout (missing root aggregator; both Tier-3 reviews read content only);


### PR DESCRIPTION
## Summary

Per beekeeper direction (2026-06-04): theory-work reviews must headline the program's critical-path question and consume mechanical verification rather than trusting body claims.

### 1. Tier-3 theory-element headline (new, required for quantitative theory claims)
Three-pillar comparison: **Experimental evidence + papers | QBP prediction + evidence | PhysLean (QM/SM) baseline + evidence** → verdict: is QBP more predictive of the evidence than the incumbent, by how much.
- **Units rule (enforced):** ALL quantities in QBP canonical format, converted ONCE at ingestion via QBP/Units with linked conversion provenance — structurally excludes the historically human-caught unit-mismatch class.
- PhysLean fallback declared: its SM layer is structure-only; where it can't produce a number, a published SM prediction is cited — never blank, never QBP grading its own homework.

### 2. Mechanical verification evidence sections (tier-2 + tier-3 templates)
Links, not assertions: clean-checkout CI build, gate scripts, differential oracle result, #print axioms audit. A claim without a link is UNVERIFIED.

### 3. Evidence-first standing rule (review_tiers.md)
- Reviewers check evidence links BEFORE content review; unlinked claims marked UNVERIFIED; ACs can't PASS on the author's word.
- The three-way headline is a review object (missing pillar / blank baseline / mixed units = BLOCKING).
- Differential FAIL/BOUNDARY rows are review objects: per-row classification (physics discrepancy / rounding artifact / fixture drift).
- Rationalization-table addition: "The PR body says the build is green" → only a clean-checkout CI link is evidence.

### Precedents motivating this (all 2026-06-04)
- #493 did not build from a clean checkout (missing root aggregator; both Tier-3 reviews read content only)
- `LieAlgebraIso.lean` never compiled since authoring (caught by aggregator wiring, not review)
- #492 1-ULP oracle inconsistency (caught by the differential run, not review)

## CTH anchor impact
- [x] N/A — process templates + workflow doc only; no anchor-bearing paths.

## Test plan
- [x] Templates render as valid markdown
- [x] CI green
- [x] Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)