### PR TITLE
[infra] PR check-status notifier — machine-stamped check verdict per head SHA

### DIFF
--- a/.github/workflows/pr-check-status.yml
+++ b/.github/workflows/pr-check-status.yml
@@ -60,21 +60,16 @@ jobs:
           NFAIL=$(echo "$FAILED" | jq 'length')
           TS=$(date -u +"%Y-%m-%d %H:%M UTC")
 
+          # NOTE: bodies are assembled with printf, not multi-line literals —
+          # YAML run-block indentation inside a quoted string becomes leading
+          # spaces that GitHub markdown renders as code blocks.
           if [ "$NFAIL" -eq 0 ]; then
-            BODY="$MARKER
-          ## ✅ All checks green — \`$TOTAL\` checks @ $TS
-
-          Head: \`$SHA\`. This comment is machine-posted and updates per head SHA; it is the canonical \"CI green\" evidence link for this PR (evidence-first rule, \`docs/workflows/review_tiers.md\`)."
+            BODY=$(printf '%s\n## ✅ All checks green — `%s` checks @ %s\n\nHead: `%s`. Machine-posted; updates per head SHA. Canonical "CI green" evidence link for this PR (evidence-first rule, `docs/workflows/review_tiers.md`).' \
+              "$MARKER" "$TOTAL" "$TS" "$SHA")
           else
             LIST=$(echo "$FAILED" | jq -r '.[] | "- ❌ [\(.name)](\(.html_url)) — \(.conclusion)"')
-            BODY="$MARKER
-          ## ❌ Checks FAILED — $NFAIL of $TOTAL @ $TS
-
-          Head: \`$SHA\`
-
-          $LIST
-
-          Machine-posted; updates per head SHA."
+            BODY=$(printf '%s\n## ❌ Checks FAILED — %s of %s @ %s\n\nHead: `%s`\n\n%s\n\nMachine-posted; updates per head SHA.' \
+              "$MARKER" "$NFAIL" "$TOTAL" "$TS" "$SHA" "$LIST")
           fi
 
           # Upsert: find existing marked comment, edit it; else create.

--- a/.github/workflows/pr-check-status.yml
+++ b/.github/workflows/pr-check-status.yml
@@ -18,6 +18,11 @@
 
 name: PR check-status notifier
 
+# KNOWN LIMITATION: check_suite payloads carry an empty pull_requests[] for
+# FORK PRs, so fork PRs get no verdict comment (acceptable for this repo:
+# solo maintainer + agent sessions, same-repo branches only — documented per
+# review finding #3 so a future external PR's silence isn't a mystery).
+
 on:
   check_suite:
     types: [completed]
@@ -27,8 +32,18 @@ permissions:
   checks: read
   contents: read
 
+# collapse simultaneous firings for the same head SHA; keep only the latest
+concurrency:
+  group: pr-check-status-${{ github.event.check_suite.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   notify:
+    # IMPORTANT: this job name is the notifier's own check-run name; the query
+    # below excludes it by name so the notifier never counts itself as pending
+    # (review finding #1 — without the self-filter, PENDING never reaches 0
+    # and the notifier structurally never posts).
+    name: pr-check-status-notify
     # only suites attached to a PR
     if: ${{ github.event.check_suite.pull_requests[0] != null }}
     runs-on: ubuntu-latest
@@ -43,9 +58,16 @@ jobs:
           set -euo pipefail
           MARKER="<!-- pr-check-status-notifier -->"
 
-          # All check runs for this SHA (across suites)
+          # All check runs for this SHA (across suites — per-SHA scoping is
+          # deliberate: the verdict covers ALL checks, not one suite), EXCLUDING
+          # the notifier's own run (self-filter, review finding #1).
+          # NOTE on pagination (review finding #8): `gh api --paginate --jq`
+          # emits one JSON array PER PAGE (concatenated docs), so we slurp and
+          # flatten to a single array before counting.
+          SELF="pr-check-status-notify"
           RUNS=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --paginate \
-                 --jq '[.check_runs[] | {name, status, conclusion, html_url}]')
+                 --jq '[.check_runs[] | {name, status, conclusion, html_url}]' \
+                 | jq -s 'add | map(select(.name != "'"$SELF"'"))')
 
           PENDING=$(echo "$RUNS" | jq '[.[] | select(.status != "completed")] | length')
           if [ "$PENDING" -gt 0 ]; then
@@ -73,8 +95,10 @@ jobs:
           fi
 
           # Upsert: find existing marked comment, edit it; else create.
+          # (slurp-flatten across pages, same pagination caveat as above)
           CID=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" --paginate \
-                --jq "[.[] | select(.body | startswith(\"$MARKER\"))] | (first // {}) | .id // empty")
+                --jq "[.[] | select(.body | startswith(\"$MARKER\"))]" \
+                | jq -s 'add | (first // {}) | .id // empty' -r)
           if [ -n "$CID" ]; then
             gh api -X PATCH "repos/$REPO/issues/comments/$CID" -f body="$BODY" > /dev/null
             echo "updated comment $CID"

--- a/.github/workflows/pr-check-status.yml
+++ b/.github/workflows/pr-check-status.yml
@@ -1,0 +1,89 @@
+# PR check-status notifier — posts ONE upserted comment per PR with the final
+# check verdict for the current head SHA, timestamped.
+#
+# Why (2026-06-04, two incidents in one day): humans and agents kept acting on
+# STALE check states — a "ready to merge" claim made without re-querying, and a
+# red verdict read after the gate had already re-run green. This makes the PR
+# conversation itself carry a machine-stamped verdict for the current head, so
+# "CI green" claims have a canonical artifact to link (evidence-first rule,
+# docs/workflows/review_tiers.md).
+#
+# Behavior:
+#   - fires when any check suite completes
+#   - if other suites for the same SHA are still running -> exits quietly
+#   - else upserts (edit-in-place, never spam) a single marked comment:
+#       ALL GREEN (N checks) @ timestamp for sha
+#       or FAILED: <names + links> @ timestamp for sha
+#   - new push -> next completion updates the comment for the new SHA
+
+name: PR check-status notifier
+
+on:
+  check_suite:
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  checks: read
+  contents: read
+
+jobs:
+  notify:
+    # only suites attached to a PR
+    if: ${{ github.event.check_suite.pull_requests[0] != null }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compose and upsert verdict comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.check_suite.pull_requests[0].number }}
+          SHA: ${{ github.event.check_suite.head_sha }}
+        run: |
+          set -euo pipefail
+          MARKER="<!-- pr-check-status-notifier -->"
+
+          # All check runs for this SHA (across suites)
+          RUNS=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --paginate \
+                 --jq '[.check_runs[] | {name, status, conclusion, html_url}]')
+
+          PENDING=$(echo "$RUNS" | jq '[.[] | select(.status != "completed")] | length')
+          if [ "$PENDING" -gt 0 ]; then
+            echo "$PENDING check(s) still running for $SHA — not posting yet."
+            exit 0
+          fi
+
+          TOTAL=$(echo "$RUNS" | jq 'length')
+          # neutral/skipped don't count as failures
+          FAILED=$(echo "$RUNS" | jq '[.[] | select(.conclusion as $c
+                    | ["failure","timed_out","cancelled","action_required"] | index($c))]')
+          NFAIL=$(echo "$FAILED" | jq 'length')
+          TS=$(date -u +"%Y-%m-%d %H:%M UTC")
+
+          if [ "$NFAIL" -eq 0 ]; then
+            BODY="$MARKER
+          ## ✅ All checks green — \`$TOTAL\` checks @ $TS
+
+          Head: \`$SHA\`. This comment is machine-posted and updates per head SHA; it is the canonical \"CI green\" evidence link for this PR (evidence-first rule, \`docs/workflows/review_tiers.md\`)."
+          else
+            LIST=$(echo "$FAILED" | jq -r '.[] | "- ❌ [\(.name)](\(.html_url)) — \(.conclusion)"')
+            BODY="$MARKER
+          ## ❌ Checks FAILED — $NFAIL of $TOTAL @ $TS
+
+          Head: \`$SHA\`
+
+          $LIST
+
+          Machine-posted; updates per head SHA."
+          fi
+
+          # Upsert: find existing marked comment, edit it; else create.
+          CID=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" --paginate \
+                --jq "[.[] | select(.body | startswith(\"$MARKER\"))] | (first // {}) | .id // empty")
+          if [ -n "$CID" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$CID" -f body="$BODY" > /dev/null
+            echo "updated comment $CID"
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$BODY" > /dev/null
+            echo "created comment"
+          fi

--- a/.github/workflows/pr-check-status.yml
+++ b/.github/workflows/pr-check-status.yml
@@ -32,9 +32,12 @@ permissions:
   checks: read
   contents: read
 
-# collapse simultaneous firings for the same head SHA; keep only the latest
+# collapse simultaneous firings per PR (not per SHA: PR-keying also cancels a
+# stale in-flight run for an OLD head SHA when a new push's suites complete,
+# so an outdated verdict can never overwrite a newer one — review concurrency
+# finding, round 1)
 concurrency:
-  group: pr-check-status-${{ github.event.check_suite.head_sha }}
+  group: pr-check-status-${{ github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

One workflow: when all check suites for a PR's head SHA complete, **upsert a single marked comment** with the verdict — ✅ `All checks green (N) @ timestamp` or ❌ failures with links. Edit-in-place (never comment spam); updates per push so it's always for the *current* head.

## Why (two incidents, same day)

1. A "ready to merge" claim was made without re-querying checks (the push had triggered new gates — red).
2. A red verdict was acted on after the gate had already re-run green.

Both are the same defect: humans and agents reading **stale check state**. This puts a machine-stamped, timestamped verdict in the PR conversation itself — the canonical "CI green" artifact the evidence-first rule (`docs/workflows/review_tiers.md`) wants linked.

## Mechanics

- Trigger: `check_suite: completed`, PR-attached suites only
- If any suite for the SHA still running → exits quietly (no partial verdicts)
- Failure = `failure | timed_out | cancelled | action_required`; neutral/skipped don't count
- Permissions: `pull-requests: write`, `checks: read` — default token, no secrets

## Self-test plan (the bootstrap)

- [ ] This PR's own checks complete → the notifier **cannot** report on this PR (the workflow only runs from the default branch for `check_suite` events) — so post-merge verification: next PR after merge gets the comment
- [ ] YAML validated (`yaml.safe_load` clean)
- [ ] CI green on this PR
- [ ] Post-merge: first comment appears on the next active PR; verify upsert (not spam) on a subsequent push

## CTH anchor impact
- [x] N/A — CI workflow only; no anchor-bearing paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)