### PR TITLE
[foundations] #474 PR-A: CDAlg carrier + multilinear lifting metalemmas (keystone)

### DIFF
--- a/proofs/QBP/Foundations.lean
+++ b/proofs/QBP/Foundations.lean
@@ -1,3 +1,5 @@
+import QBP.Foundations.CDAlg
+import QBP.Foundations.CDLifting
 import QBP.Foundations.FanoOrientationF3
 import QBP.Foundations.LieAlgebraIso
 import QBP.Foundations.Operations

--- a/proofs/QBP/Foundations/CDAlg.lean
+++ b/proofs/QBP/Foundations/CDAlg.lean
@@ -1,0 +1,567 @@
+/-
+  QBP.Foundations.CDAlg
+  =====================
+
+  The Cayley–Dickson carrier `CDAlg R n` — a ring-generic coordinate algebra of
+  dimension `2^n` over a commutative ring `R`, with multiplication given by the
+  Cayley–Dickson structure constants `mulCoeff`.  This is the keystone carrier the
+  #474 / #476 / #477 operations-complete program consumes: ℝ→ℂ→ℍ→𝕆→𝕊 are the
+  instances `CDAlg R 0..4`.
+
+  Design (federation Lean standard, ~/Documents/inter/lean-proof-best-practices.md):
+  * `CDAlg` carries ONLY the structure that genuinely holds at every level:
+    `AddCommGroup`, `Module R`, `One`, `Mul`.  It is deliberately NOT a `Ring`
+    (𝕆 is non-associative, 𝕊 is non-alternative) — see the operations-complete
+    matrix in `docs/foundations/scope-deliberation-2026-05-31.md`.
+  * `mulCoeff` is DEFINED by the genuine Cayley–Dickson doubling recursion
+    `(a,b)(c,d) = (ac − d̄b, da + bc̄)` on the high-bit / low-index split of each
+    `Fin (2^n)` index.  Its correctness is pinned by `mulCoeff_four_eq_sgnTable`:
+    it agrees on all 256 basis pairs (kernel `decide`) with the independently
+    kernel-verified sedenion sign table `SedenionOctonionCount.sgnTable`, and by
+    `mulCoeff_three_eq_fano` with the F3 octonion construction.  No table is
+    transcribed by hand here.
+  * Multiplication is `e_i · e_j = mulCoeff n i j • e_{i ⊕ j}` (XOR-on-`Fin`
+    index encoding, consistent with `SedenionOctonionCount` / `FanoOrientationF3`).
+
+  Completeness: zero `sorry`, zero `native_decide`, zero vacuous `True`.
+  `#print axioms` audit at the bottom — every main result depends only on
+  `{propext, Classical.choice, Quot.sound}`.
+-/
+import Mathlib.Tactic
+import Mathlib.Algebra.Module.Basic
+import QBP.Foundations.SedenionOctonionCount
+import QBP.Foundations.FanoOrientationF3
+
+namespace QBP.Foundations.CDAlg
+
+/-! ## 1. The carrier and its module structure -/
+
+/-- The Cayley–Dickson carrier of dimension `2^n` over `R`: a tuple of `2^n`
+    coordinates.  Levels ℝ,ℂ,ℍ,𝕆,𝕊 are `n = 0,1,2,3,4`. -/
+structure CDAlg (R : Type*) [CommRing R] (n : ℕ) where
+  /-- The coordinate vector. -/
+  coord : Fin (2^n) → R
+
+variable {R : Type*} [CommRing R] {n : ℕ}
+
+@[ext] theorem ext (x y : CDAlg R n) (h : ∀ i, x.coord i = y.coord i) : x = y := by
+  cases x; cases y; simp only [CDAlg.mk.injEq]; funext i; exact h i
+
+instance : Add (CDAlg R n) := ⟨fun x y => ⟨fun i => x.coord i + y.coord i⟩⟩
+instance : Zero (CDAlg R n) := ⟨⟨fun _ => 0⟩⟩
+instance : Neg (CDAlg R n) := ⟨fun x => ⟨fun i => - x.coord i⟩⟩
+instance : SMul R (CDAlg R n) := ⟨fun r x => ⟨fun i => r * x.coord i⟩⟩
+
+@[simp] theorem add_coord (x y : CDAlg R n) (i) : (x + y).coord i = x.coord i + y.coord i := rfl
+@[simp] theorem zero_coord (i) : (0 : CDAlg R n).coord i = 0 := rfl
+@[simp] theorem neg_coord (x : CDAlg R n) (i) : (-x).coord i = - x.coord i := rfl
+@[simp] theorem smul_coord (r : R) (x : CDAlg R n) (i) : (r • x).coord i = r * x.coord i := rfl
+
+instance : AddCommGroup (CDAlg R n) where
+  add_assoc a b c := by ext i; simp [add_assoc]
+  zero_add a := by ext i; simp
+  add_zero a := by ext i; simp
+  neg_add_cancel a := by ext i; simp
+  add_comm a b := by ext i; simp [add_comm]
+  nsmul := nsmulRec
+  zsmul := zsmulRec
+
+instance : Module R (CDAlg R n) where
+  one_smul a := by ext i; simp
+  mul_smul r s a := by ext i; simp [mul_assoc]
+  smul_zero r := by ext i; simp
+  smul_add r a b := by ext i; simp [mul_add]
+  add_smul r s a := by ext i; simp [add_mul]
+  zero_smul a := by ext i; simp
+
+@[simp] theorem sub_coord (x y : CDAlg R n) (i) : (x - y).coord i = x.coord i - y.coord i := by
+  rw [sub_eq_add_neg, add_coord, neg_coord, sub_eq_add_neg]
+
+/-! ## 2. Basis and basis expansion -/
+
+/-- The basis element `eᵢ`: a 1 in coordinate `i`, 0 elsewhere. -/
+def e (i : Fin (2^n)) : CDAlg R n := ⟨fun j => if j = i then 1 else 0⟩
+
+@[simp] theorem e_coord (i j : Fin (2^n)) : (e i : CDAlg R n).coord j = if j = i then 1 else 0 := rfl
+
+/-- The coordinate of a `Finset.sum` is the sum of coordinates. -/
+theorem sum_coord {ι : Type*} (s : Finset ι) (f : ι → CDAlg R n) (j : Fin (2^n)) :
+    (∑ i ∈ s, f i).coord j = ∑ i ∈ s, (f i).coord j := by
+  classical
+  induction s using Finset.induction with
+  | empty => simp
+  | insert a s ha ih => rw [Finset.sum_insert ha, Finset.sum_insert ha, add_coord, ih]
+
+/-- **Basis expansion.**  Every element is the sum of its coordinates times basis
+    vectors: `x = ∑ i, x.coord i • eᵢ`. -/
+theorem basis_expansion (x : CDAlg R n) : x = ∑ i, x.coord i • e i := by
+  ext j
+  rw [sum_coord]
+  simp only [smul_coord, e_coord, mul_ite, mul_one, mul_zero]
+  rw [Finset.sum_ite_eq Finset.univ j (fun i => x.coord i)]
+  simp
+
+/-! ## 3. Cayley–Dickson structure constants `mulCoeff`
+
+The recursion mirrors the doubling product `(a,b)(c,d) = (ac − d̄b, da + bc̄)`,
+splitting each `Fin (2^(n+1))` index into a high bit (component selector) and a
+low part (index within the component). -/
+
+/-- Conjugation sign of a basis index: `+1` for the real unit (index 0), `−1` for
+    every imaginary unit.  `conj eᵢ = conjSign n i • eᵢ`. -/
+def conjSign (n : ℕ) (i : Fin (2^n)) : Int := if i.val = 0 then 1 else -1
+
+/-- Cayley–Dickson structure constant: `eᵢ · e_j = mulCoeff n i j • e_{i ⊕ j}`. -/
+def mulCoeff : (n : ℕ) → Fin (2^n) → Fin (2^n) → Int
+  | 0, _, _ => 1
+  | n+1, i, j =>
+    let half : ℕ := 2^n
+    let pi : ℕ := i.val / half
+    let ai : ℕ := i.val % half
+    let pj : ℕ := j.val / half
+    let aj : ℕ := j.val % half
+    have hai : ai < 2^n := Nat.mod_lt _ (Nat.pos_of_ne_zero (by positivity))
+    have haj : aj < 2^n := Nat.mod_lt _ (Nat.pos_of_ne_zero (by positivity))
+    let a : Fin (2^n) := ⟨ai, hai⟩
+    let c : Fin (2^n) := ⟨aj, haj⟩
+    match pi, pj with
+    | 0, 0 => mulCoeff n a c                       -- (a,0)(c,0) → (ac, 0)
+    | 0, 1 => mulCoeff n c a                       -- (a,0)(0,d) → (0, da)
+    | 1, 0 => conjSign n c * mulCoeff n a c        -- (0,b)(c,0) → (0, b c̄)
+    | _, _ => - (conjSign n c * mulCoeff n c a)    -- (0,b)(0,d) → (-d̄ b, 0)
+
+/-- **Provenance: agreement with the sedenion sign table (n = 4).**  `mulCoeff 4`
+    equals the kernel-verified `SedenionOctonionCount.sgnTable` on all 256 basis
+    pairs.  This pins the recursion to the independently-built CD sedenion table —
+    no hand-transcription. -/
+theorem mulCoeff_four_eq_sgnTable :
+    ∀ i j : Fin 16, mulCoeff 4 i j = QBP.Foundations.SedenionOctonionCount.sgnTable i j := by
+  decide
+
+/-- **Provenance: agreement with the F3 octonion construction (n = 3).**  For all
+    basis indices `i j : Fin 8`, the `mulCoeff 3` sign equals the sign of the F3
+    Cayley–Dickson octonion product `Omul (e i) (e j)` (from `FanoOrientationF3`),
+    whose table is `eᵢ·e_j = (fanoTableF4 i j).1 • e_{(fanoTableF4 i j).2}`. -/
+theorem mulCoeff_three_eq_fano :
+    ∀ i j : Fin 8,
+      mulCoeff 3 i j = (QBP.Foundations.FanoOrientationF3.fanoTableF4 i j).1 := by
+  decide
+
+/-! ## 4. Multiplication via structure constants -/
+
+instance : One (CDAlg R n) := ⟨e 0⟩
+
+theorem one_def : (1 : CDAlg R n) = e 0 := rfl
+
+@[simp] theorem one_coord (k : Fin (2^n)) :
+    (1 : CDAlg R n).coord k = if k = 0 then 1 else 0 := rfl
+
+instance : Mul (CDAlg R n) :=
+  ⟨fun x y => ⟨fun k => ∑ i, ∑ j, if (i ^^^ j : Fin (2^n)) = k then
+      (mulCoeff n i j : R) * x.coord i * y.coord j else 0⟩⟩
+
+theorem mul_coord (x y : CDAlg R n) (k : Fin (2^n)) :
+    (x * y).coord k = ∑ i, ∑ j, if (i ^^^ j : Fin (2^n)) = k then
+      (mulCoeff n i j : R) * x.coord i * y.coord j else 0 := rfl
+
+/-- **Product of two basis elements:** `eᵢ · e_j = mulCoeff n i j • e_{i ⊕ j}`. -/
+theorem e_mul_e (i j : Fin (2^n)) :
+    (e i * e j : CDAlg R n) = (mulCoeff n i j : R) • e (i ^^^ j) := by
+  ext k
+  rw [mul_coord, smul_coord, e_coord]
+  rw [Finset.sum_eq_single i]
+  · rw [Finset.sum_eq_single j]
+    · simp only [e_coord, if_true]
+      by_cases h : (i ^^^ j : Fin (2^n)) = k
+      · simp [h]
+      · rw [if_neg h, if_neg (fun hk => h hk.symm), mul_zero]
+    · intro b _ hb; simp only [e_coord, if_neg hb, mul_zero]; split <;> rfl
+    · intro h; simp at h
+  · intro b _ hb
+    apply Finset.sum_eq_zero; intro q _
+    simp only [e_coord, if_neg hb, mul_zero, zero_mul]; split <;> rfl
+  · intro h; simp at h
+
+/-! ## 5. Bilinearity of multiplication -/
+
+/-- Multiplication is additive in the left argument. -/
+theorem mul_add_left (x x' y : CDAlg R n) : (x + x') * y = x * y + x' * y := by
+  ext k
+  simp only [mul_coord, add_coord, ← Finset.sum_add_distrib]
+  refine Finset.sum_congr rfl (fun i _ => Finset.sum_congr rfl (fun j _ => ?_))
+  by_cases h : (i ^^^ j : Fin (2^n)) = k <;> simp [h, mul_add, add_mul]
+
+/-- Multiplication is additive in the right argument. -/
+theorem mul_add_right (x y y' : CDAlg R n) : x * (y + y') = x * y + x * y' := by
+  ext k
+  simp only [mul_coord, add_coord, ← Finset.sum_add_distrib]
+  refine Finset.sum_congr rfl (fun i _ => Finset.sum_congr rfl (fun j _ => ?_))
+  by_cases h : (i ^^^ j : Fin (2^n)) = k <;> simp [h, mul_add]
+
+/-- Multiplication is `R`-homogeneous in the left argument. -/
+theorem mul_smul_left (r : R) (x y : CDAlg R n) : (r • x) * y = r • (x * y) := by
+  ext k
+  simp only [mul_coord, smul_coord, Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun i _ => Finset.sum_congr rfl (fun j _ => ?_))
+  by_cases h : (i ^^^ j : Fin (2^n)) = k <;> simp only [h, if_true, if_false] <;> ring
+
+/-- Multiplication is `R`-homogeneous in the right argument. -/
+theorem mul_smul_right (r : R) (x y : CDAlg R n) : x * (r • y) = r • (x * y) := by
+  ext k
+  simp only [mul_coord, smul_coord, Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun i _ => Finset.sum_congr rfl (fun j _ => ?_))
+  by_cases h : (i ^^^ j : Fin (2^n)) = k <;> simp only [h, if_true, if_false] <;> ring
+
+/-! ## 6. Conjugation, real/imaginary parts, norm form -/
+
+/-- Conjugation: negate every imaginary coordinate, fix the real one. -/
+def conj (x : CDAlg R n) : CDAlg R n :=
+  ⟨fun i => if i.val = 0 then x.coord i else - x.coord i⟩
+
+@[simp] theorem conj_coord (x : CDAlg R n) (i) :
+    (conj x).coord i = if i.val = 0 then x.coord i else - x.coord i := rfl
+
+/-- Real (scalar) part: the coefficient on `e₀`, returned as a scalar. -/
+def reCoord (x : CDAlg R n) : R := x.coord 0
+
+/-- The norm FORM `N(x) = ∑ xᵢ²`.  This is the algebraic norm form (sum of squares
+    of coordinates), NOT identified with any spacetime metric (non-identification
+    clause, scope-deliberation §5 guardrail 1). -/
+def N (x : CDAlg R n) : R := ∑ i, (x.coord i)^2
+
+@[simp] theorem N_def (x : CDAlg R n) : N x = ∑ i, (x.coord i)^2 := rfl
+
+/-! ## 7. Structural facts about `mulCoeff` (general `n`, by induction)
+
+These power the quadraticity theorem (§8) and downstream conjugation/norm laws. -/
+
+/-- The low part of an index at level `n+1`. -/
+def lo (n : ℕ) (i : Fin (2^(n+1))) : Fin (2^n) :=
+  ⟨i.val % 2^n, Nat.mod_lt _ (by positivity)⟩
+
+theorem lo_val (n : ℕ) (i : Fin (2^(n+1))) : (lo n i).val = i.val % 2^n := rfl
+
+theorem zero_mk_eq (n : ℕ) (h) : (⟨0, h⟩ : Fin (2^n)) = 0 := by apply Fin.ext; simp
+
+theorem div_lt_two (n : ℕ) (j : Fin (2^(n+1))) : j.val / 2^n < 2 := by
+  have hj : j.val < 2^(n+1) := j.isLt
+  have h2 : (2:ℕ)^(n+1) = 2^n * 2 := by ring
+  exact Nat.div_lt_of_lt_mul (h2 ▸ hj)
+
+theorem div_zero_or_one (n : ℕ) (j : Fin (2^(n+1))) :
+    j.val / 2^n = 0 ∨ j.val / 2^n = 1 := by
+  have h := div_lt_two n j
+  generalize j.val / 2^n = q at h ⊢
+  omega
+
+theorem conjSign_zero_of (n : ℕ) (i : Fin (2^n)) (hi : i.val = 0) : conjSign n i = 1 := by
+  unfold conjSign; simp [hi]
+
+theorem conjSign_neg_of (n : ℕ) (i : Fin (2^n)) (hi : i.val ≠ 0) : conjSign n i = -1 := by
+  unfold conjSign; simp [hi]
+
+theorem lt_two_pow_of_div_zero (n : ℕ) (i : Fin (2^(n+1))) (h : i.val / 2^n = 0) :
+    i.val < 2^n := by
+  by_contra hge
+  push_neg at hge
+  have : i.val / 2^n ≥ 1 := Nat.one_le_div_iff (by positivity) |>.mpr hge
+  omega
+
+theorem mod_eq_self_of_div_zero (n : ℕ) (i : Fin (2^(n+1))) (h : i.val / 2^n = 0) :
+    i.val % 2^n = i.val :=
+  Nat.mod_eq_of_lt (lt_two_pow_of_div_zero n i h)
+
+theorem val_eq_zero_iff (n : ℕ) (i : Fin (2^(n+1))) :
+    i.val = 0 ↔ i.val / 2^n = 0 ∧ (lo n i).val = 0 := by
+  rw [lo_val]
+  constructor
+  · intro h; rw [h]; simp
+  · rintro ⟨hd, hm⟩
+    have h1 := Nat.div_add_mod i.val (2^n)
+    rw [hd, hm] at h1; omega
+
+theorem eq_of_hi_lo (n : ℕ) (i j : Fin (2^(n+1)))
+    (hd : i.val / 2^n = j.val / 2^n) (hm : (lo n i).val = (lo n j).val) : i = j := by
+  apply Fin.ext
+  rw [lo_val, lo_val] at hm
+  have hi := Nat.div_add_mod i.val (2^n)
+  have hj := Nat.div_add_mod j.val (2^n)
+  rw [hd, hm] at hi; omega
+
+/-- Combined structural facts about `mulCoeff`, proven by induction on `n`:
+    products with the real unit are `+1`; squares of units are `+1` (real) / `−1`
+    (imaginary); and distinct imaginary units anticommute. -/
+theorem mulCoeff_props : ∀ n : ℕ,
+    (∀ j : Fin (2^n), mulCoeff n 0 j = 1) ∧
+    (∀ i : Fin (2^n), mulCoeff n i 0 = 1) ∧
+    (∀ i : Fin (2^n), mulCoeff n i i = if i.val = 0 then 1 else -1) ∧
+    (∀ i j : Fin (2^n), i.val ≠ 0 → j.val ≠ 0 → i ≠ j →
+        mulCoeff n i j = - mulCoeff n j i) := by
+  intro n
+  induction n with
+  | zero =>
+    refine ⟨fun j => ?_, fun i => ?_, fun i => ?_, fun i j _ _ hij => ?_⟩
+    · rfl
+    · rfl
+    · fin_cases i; rfl
+    · exfalso; apply hij; apply Fin.ext
+      have h1 : i.val < 2^0 := i.isLt
+      have h2 : j.val < 2^0 := j.isLt
+      simp only [pow_zero] at h1 h2; omega
+  | succ n ih =>
+    obtain ⟨ihL, ihR, ihS, ihA⟩ := ih
+    refine ⟨fun j => ?_, fun i => ?_, fun i => ?_, fun i j hi0 hj0 hij => ?_⟩
+    · rw [mulCoeff]
+      simp only [Fin.val_zero, Nat.zero_div, Nat.zero_mod]
+      rcases div_zero_or_one n j with hpj | hpj
+      · rw [hpj]; simp only [zero_mk_eq]; exact ihL _
+      · rw [hpj]; simp only [zero_mk_eq]; exact ihR _
+    · rw [mulCoeff]
+      simp only [Fin.val_zero, Nat.zero_div, Nat.zero_mod]
+      rcases div_zero_or_one n i with hpi | hpi
+      · rw [hpi]; simp only [zero_mk_eq]; exact ihR _
+      · rw [hpi]; simp only [zero_mk_eq]
+        rw [conjSign_zero_of n _ (by rfl), one_mul]; exact ihR _
+    · rw [mulCoeff]
+      rcases div_zero_or_one n i with hpi | hpi
+      · rw [hpi]
+        have hmod : i.val % 2^n = i.val := mod_eq_self_of_div_zero n i hpi
+        rw [ihS ⟨i.val % 2^n, _⟩]; simp only [hmod]
+      · rw [hpi]
+        have hi0' : i.val ≠ 0 := by
+          intro h0
+          have hz : i.val / 2^n = 0 := by rw [h0]; simp
+          rw [hz] at hpi; exact absurd hpi (by norm_num)
+        rw [if_neg hi0']
+        by_cases hlow : (i.val % 2^n) = 0
+        · rw [conjSign_zero_of n ⟨i.val % 2^n, _⟩ (by simpa using hlow)]
+          rw [ihS ⟨i.val % 2^n, _⟩]; simp [hlow]
+        · rw [conjSign_neg_of n ⟨i.val % 2^n, _⟩ (by simpa using hlow)]
+          rw [ihS ⟨i.val % 2^n, _⟩]; simp [hlow]
+    · -- antisymmetry
+      set a : Fin (2^n) := ⟨i.val % 2^n, Nat.mod_lt _ (by positivity)⟩ with ha
+      set c : Fin (2^n) := ⟨j.val % 2^n, Nat.mod_lt _ (by positivity)⟩ with hc
+      have hai : (lo n i).val = a.val := rfl
+      have hcj : (lo n j).val = c.val := rfl
+      rw [mulCoeff, mulCoeff]
+      rcases div_zero_or_one n i with hpi | hpi <;>
+        rcases div_zero_or_one n j with hpj | hpj <;>
+        rw [hpi, hpj] <;> simp only [← ha, ← hc]
+      · have hane : a.val ≠ 0 := fun h =>
+          hi0 ((val_eq_zero_iff n i).mpr ⟨hpi, by rw [hai]; exact h⟩)
+        have hcne : c.val ≠ 0 := fun h =>
+          hj0 ((val_eq_zero_iff n j).mpr ⟨hpj, by rw [hcj]; exact h⟩)
+        have hac : a ≠ c := fun h =>
+          hij (eq_of_hi_lo n i j (by rw [hpi, hpj]) (by rw [hai, hcj, h]))
+        exact ihA a c hane hcne hac
+      · have hane : a.val ≠ 0 := fun h =>
+          hi0 ((val_eq_zero_iff n i).mpr ⟨hpi, by rw [hai]; exact h⟩)
+        rw [conjSign_neg_of n a hane]; ring
+      · have hcne : c.val ≠ 0 := fun h =>
+          hj0 ((val_eq_zero_iff n j).mpr ⟨hpj, by rw [hcj]; exact h⟩)
+        rw [conjSign_neg_of n c hcne]; ring
+      · have hac : a ≠ c := fun h =>
+          hij (eq_of_hi_lo n i j (by rw [hpi, hpj]) (by rw [hai, hcj, h]))
+        have haeq : a = 0 → mulCoeff n c a = 1 ∧ mulCoeff n a c = 1 := by
+          intro h; rw [h]; exact ⟨ihR c, ihL c⟩
+        have hceq : c = 0 → mulCoeff n c a = 1 ∧ mulCoeff n a c = 1 := by
+          intro h; rw [h]; exact ⟨ihL a, ihR a⟩
+        by_cases haz : a.val = 0
+        · have ha0 : a = 0 := Fin.ext haz
+          have hcne : c.val ≠ 0 := fun h => hac (Fin.ext (by rw [haz, h]))
+          rw [conjSign_neg_of n c hcne, conjSign_zero_of n a haz]
+          obtain ⟨e1, e2⟩ := haeq ha0; rw [e1, e2]; ring
+        · by_cases hcz : c.val = 0
+          · have hc0 : c = 0 := Fin.ext hcz
+            rw [conjSign_zero_of n c hcz, conjSign_neg_of n a haz]
+            obtain ⟨e1, e2⟩ := hceq hc0; rw [e1, e2]; ring
+          · rw [conjSign_neg_of n c hcz, conjSign_neg_of n a haz]
+            rw [ihA c a hcz haz (fun h => hac h.symm)]; ring
+
+/-- `eₐ · e₀ = eₐ` at the coefficient level: `mulCoeff n 0 j = 1`. -/
+theorem mulCoeff_zero_left (n : ℕ) (j : Fin (2^n)) : mulCoeff n 0 j = 1 :=
+  (mulCoeff_props n).1 j
+/-- `mulCoeff n i 0 = 1`. -/
+theorem mulCoeff_zero_right (n : ℕ) (i : Fin (2^n)) : mulCoeff n i 0 = 1 :=
+  (mulCoeff_props n).2.1 i
+/-- Unit squares: `mulCoeff n i i = +1` (real) / `−1` (imaginary). -/
+theorem mulCoeff_self (n : ℕ) (i : Fin (2^n)) :
+    mulCoeff n i i = if i.val = 0 then 1 else -1 :=
+  (mulCoeff_props n).2.2.1 i
+/-- Distinct imaginary units anticommute: `mulCoeff n i j = − mulCoeff n j i`. -/
+theorem mulCoeff_antisymm (n : ℕ) (i j : Fin (2^n))
+    (hi : i.val ≠ 0) (hj : j.val ≠ 0) (hij : i ≠ j) :
+    mulCoeff n i j = - mulCoeff n j i :=
+  (mulCoeff_props n).2.2.2 i j hi hj hij
+
+/-! ## 8. Quadraticity: `x·x = (2 Re x)·x − N(x)·1`
+
+The Cayley–Dickson identity that powers the exp/log construction (span{1,x} ≅ ℂ).
+Proven structurally (ℝ-coordinates are not decidable) via the `mulCoeff`
+structural lemmas of §7. -/
+
+/-- `i ⊕ 0 = i` on `Fin (2^n)`. -/
+theorem xor_zero_right (i : Fin (2^n)) : (i ^^^ (0 : Fin (2^n))) = i := by
+  apply Fin.ext; rw [Fin.xor_val_of_two_pow]; simp
+
+/-- `0 ⊕ k = k`. -/
+theorem xor_zero_left (k : Fin (2^n)) : ((0 : Fin (2^n)) ^^^ k) = k := by
+  apply Fin.ext; rw [Fin.xor_val_of_two_pow]; simp
+
+/-- `i ⊕ i = 0`. -/
+theorem xor_self_eq (i : Fin (2^n)) : (i ^^^ i) = (0 : Fin (2^n)) := by
+  apply Fin.ext; rw [Fin.xor_val_of_two_pow, Nat.xor_self]; rfl
+
+/-- XOR by `k` is an involution: `(i ⊕ k) ⊕ k = i`. -/
+theorem xor_xor_cancel (i k : Fin (2^n)) : ((i ^^^ k) ^^^ k) = i := by
+  apply Fin.ext
+  rw [Fin.xor_val_of_two_pow, Fin.xor_val_of_two_pow, Nat.xor_assoc, Nat.xor_self, Nat.xor_zero]
+
+/-- XOR by a fixed `i` on the left is injective. -/
+theorem xor_left_injective (i : Fin (2^n)) : Function.Injective (i ^^^ ·) := by
+  intro a b h
+  apply Fin.ext
+  have hv : i.val ^^^ a.val = i.val ^^^ b.val := by
+    have := congrArg Fin.val h
+    rwa [Fin.xor_val_of_two_pow, Fin.xor_val_of_two_pow] at this
+  have h2 : i.val ^^^ (i.val ^^^ a.val) = i.val ^^^ (i.val ^^^ b.val) := by rw [hv]
+  rwa [← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor, ← Nat.xor_assoc, Nat.xor_self,
+    Nat.zero_xor] at h2
+
+/-- XOR is an involution: `i ⊕ j = k ↔ j = i ⊕ k` on `Fin (2^n)`. -/
+theorem xor_eq_iff (i j k : Fin (2^n)) : (i ^^^ j = k) ↔ (j = i ^^^ k) := by
+  constructor
+  · intro h; apply Fin.ext; subst h
+    simp only [Fin.xor_val_of_two_pow]
+    rw [← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor]
+  · intro h; apply Fin.ext; subst h
+    simp only [Fin.xor_val_of_two_pow]
+    rw [← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor]
+
+/-- The product coordinate `(x·y).coord k` collapses to a single sum over `i`
+    (picking `j = i ⊕ k`). -/
+theorem mul_coord_single (x y : CDAlg R n) (k : Fin (2^n)) :
+    (x * y).coord k =
+      ∑ i, (mulCoeff n i (i ^^^ k) : R) * x.coord i * y.coord (i ^^^ k) := by
+  rw [mul_coord]
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  rw [Finset.sum_eq_single (i ^^^ k)]
+  · rw [if_pos]; exact (xor_eq_iff i (i ^^^ k) k).mpr rfl
+  · intro b _ hb
+    rw [if_neg]; intro h; exact hb ((xor_eq_iff i b k).mp h)
+  · intro h; exact absurd (Finset.mem_univ _) h
+
+/-- **Quadraticity (Cayley–Dickson square identity).**  For every `x : CDAlg ℝ n`,
+    `x · x = (2 · Re x) • x − N(x) • 1`, where `Re x = x.coord 0` and
+    `N x = ∑ xᵢ²`.  This is the identity span{1, x} ≅ ℂ rests on. -/
+theorem cdAlg_sq_eq (x : CDAlg ℝ n) :
+    x * x = (2 * x.coord 0) • x - (N x) • 1 := by
+  ext k
+  rw [mul_coord_single, sub_coord, smul_coord, smul_coord, one_coord, N_def]
+  by_cases hk : k = 0
+  · -- real coordinate: ∑ᵢ mulCoeff i i · xᵢ² = 2 x₀² − N x
+    subst hk
+    simp only [xor_zero_right, mul_one]
+    -- LHS = ∑ᵢ mulCoeff i i · xᵢ · xᵢ ; mulCoeff i i = ±1
+    rw [show (∑ i, (mulCoeff n i i : ℝ) * x.coord i * x.coord i)
+          = ∑ i, (if i.val = 0 then (1:ℝ) else -1) * x.coord i * x.coord i from
+        Finset.sum_congr rfl (fun i _ => by rw [mulCoeff_self]; split <;> push_cast <;> ring)]
+    -- split the singleton i=0 from both sums
+    rw [show (∑ i, (if i.val = 0 then (1:ℝ) else -1) * x.coord i * x.coord i)
+          = ∑ i, ((if i.val = 0 then (2:ℝ) else 0) * x.coord i ^ 2
+                   - x.coord i ^ 2) from
+        Finset.sum_congr rfl (fun i _ => by split <;> ring)]
+    rw [Finset.sum_sub_distrib]
+    rw [show (∑ i, (if i.val = 0 then (2:ℝ) else 0) * x.coord i ^ 2)
+          = ∑ i, (if i = 0 then (2:ℝ) * x.coord i ^ 2 else 0) from
+        Finset.sum_congr rfl (fun i _ => by
+          by_cases h : i = 0
+          · subst h; simp
+          · have hv : i.val ≠ 0 := fun hh => h (Fin.ext hh)
+            rw [if_neg h, if_neg hv]; ring)]
+    rw [Finset.sum_ite_eq' Finset.univ (0 : Fin (2^n)) (fun i => (2:ℝ) * x.coord i ^ 2)]
+    simp only [Finset.mem_univ, if_true]
+    ring
+  · -- imaginary coordinate k ≠ 0: ∑ᵢ mulCoeff i (i⊕k) xᵢ x_{i⊕k} = 2 x₀ x_k
+    rw [if_neg hk, mul_zero, sub_zero]
+    -- the i=0 and i=k terms; everything else cancels pairwise
+    -- ∑ᵢ f i with f i = mulCoeff i (i⊕k) xᵢ x_{i⊕k}
+    -- pair i ↔ i⊕k.  Use Finset.sum over an involution.
+    have hknz : (k.val) ≠ 0 := fun h => hk (Fin.ext h)
+    have key : (∑ i, (mulCoeff n i (i ^^^ k) : ℝ) * x.coord i * x.coord (i ^^^ k))
+                = 2 * x.coord 0 * x.coord k := by
+      -- Symmetrize over the involution σ i = i ⊕ k: 2·S = ∑ (mc i (i⊕k) + mc (i⊕k) i)·xᵢ·x_{i⊕k};
+      -- the antisymmetric (both-imaginary) pairs cancel, leaving i=0 and i=k.
+      -- reindex i ↦ i⊕k: ∑ g i = ∑ g (i⊕k), and g(i⊕k) is the swapped summand
+      have hreindex : ∀ g : Fin (2^n) → ℝ, (∑ i, g i) = ∑ i, g (i ^^^ k) := by
+        intro g
+        apply Finset.sum_nbij' (fun i => i ^^^ k) (fun i => i ^^^ k) <;>
+          intro a _ <;>
+          first
+            | exact Finset.mem_univ _
+            | exact xor_xor_cancel a k
+            | exact congrArg g (xor_xor_cancel a k).symm
+      have hsum_swap : (∑ i, (mulCoeff n i (i ^^^ k) : ℝ) * x.coord i * x.coord (i ^^^ k))
+            = ∑ i, (mulCoeff n (i ^^^ k) i : ℝ) * x.coord (i ^^^ k) * x.coord i := by
+        rw [hreindex (fun i => (mulCoeff n i (i ^^^ k) : ℝ) * x.coord i * x.coord (i ^^^ k))]
+        exact Finset.sum_congr rfl (fun i _ => by rw [xor_xor_cancel i k])
+      have h2S : (2:ℝ) * (∑ i, (mulCoeff n i (i ^^^ k) : ℝ) * x.coord i * x.coord (i ^^^ k))
+            = ∑ i, ((mulCoeff n i (i ^^^ k) : ℝ) + (mulCoeff n (i ^^^ k) i : ℝ))
+                      * x.coord i * x.coord (i ^^^ k) := by
+        rw [two_mul]
+        nth_rewrite 2 [hsum_swap]
+        rw [← Finset.sum_add_distrib]
+        exact Finset.sum_congr rfl (fun i _ => by ring)
+      have hterm : ∀ i : Fin (2^n),
+          ((mulCoeff n i (i ^^^ k) : ℝ) + (mulCoeff n (i ^^^ k) i : ℝ))
+              * x.coord i * x.coord (i ^^^ k)
+            = (if i = 0 then (2:ℝ) * x.coord 0 * x.coord k else 0)
+              + (if i = k then (2:ℝ) * x.coord 0 * x.coord k else 0) := by
+        intro i
+        by_cases hi0 : i = 0
+        · subst hi0
+          rw [xor_zero_left, mulCoeff_zero_left, mulCoeff_zero_right]
+          rw [if_pos rfl, if_neg (fun h => hk h.symm)]
+          push_cast; ring
+        · by_cases hik : i = k
+          · subst hik
+            rw [xor_self_eq, mulCoeff_zero_left, mulCoeff_zero_right]
+            rw [if_neg hi0, if_pos rfl]
+            push_cast; ring
+          · have hiknz : i.val ≠ 0 := fun h => hi0 (Fin.ext h)
+            have hixk_nz : (i ^^^ k).val ≠ 0 := by
+              intro h
+              have h0 : (i ^^^ k) = 0 := Fin.ext h
+              exact hik (by rw [← xor_xor_cancel i k, h0, xor_zero_left])
+            have hne : i ≠ (i ^^^ k) := by
+              intro h
+              -- h : i = i ⊕ k ⟹ k = 0, contradiction with hk
+              apply hk
+              apply xor_left_injective i
+              show i ^^^ k = i ^^^ 0
+              rw [xor_zero_right, ← h]
+            rw [mulCoeff_antisymm n i (i ^^^ k) hiknz hixk_nz hne]
+            rw [if_neg hi0, if_neg hik]
+            push_cast; ring
+      have hexpand : (2:ℝ) * (∑ i, (mulCoeff n i (i ^^^ k) : ℝ) * x.coord i * x.coord (i ^^^ k))
+            = 2 * ((2:ℝ) * x.coord 0 * x.coord k) := by
+        rw [h2S, Finset.sum_congr rfl (fun i _ => hterm i), Finset.sum_add_distrib]
+        rw [Finset.sum_ite_eq' Finset.univ (0 : Fin (2^n)) (fun _ => (2:ℝ) * x.coord 0 * x.coord k)]
+        rw [Finset.sum_ite_eq' Finset.univ k (fun _ => (2:ℝ) * x.coord 0 * x.coord k)]
+        simp only [Finset.mem_univ, if_true]; ring
+      linarith [hexpand]
+    rw [key, mul_assoc]
+
+/-! ## 9. Completeness audit — `#print axioms` -/
+
+#print axioms basis_expansion
+#print axioms mulCoeff_four_eq_sgnTable
+#print axioms mulCoeff_three_eq_fano
+#print axioms e_mul_e
+#print axioms mul_add_left
+#print axioms mul_smul_left
+#print axioms mulCoeff_self
+#print axioms mulCoeff_antisymm
+#print axioms cdAlg_sq_eq
+
+end QBP.Foundations.CDAlg

--- a/proofs/QBP/Foundations/CDLifting.lean
+++ b/proofs/QBP/Foundations/CDLifting.lean
@@ -1,0 +1,399 @@
+/-
+  QBP.Foundations.CDLifting
+  =========================
+
+  The multilinear lifting metalemmas for `CDAlg R n` — the keystone the
+  operations-complete program (#474 / #476 / #477) consumes.  An algebra-wide law
+  (associativity, alternativity, Moufang, …) holds for ALL elements iff it holds
+  on all basis tuples, PROVIDED the law's defining map is multilinear.  This file
+  proves that bridge once, in three arities:
+
+    * `lift_bilinear_eq`     — 2 arguments  (powers e.g. commutator laws)
+    * `lift_trilinear_eq`    — 3 arguments  (KEYSTONE; powers associativity /
+                                             alternativity)
+    * `lift_quadrilinear_eq` — 4 arguments  (powers the Moufang identities, PR-C1)
+
+  and demonstrates them end-to-end:
+
+    * `octonion_alternative`        — 𝕆 = CDAlg ℝ 3 is left- and right-alternative
+                                      (basis fact `decide`d over ℤ + trilinear lift)
+    * `sedenion_not_alternative`    — 𝕊 = CDAlg ℝ 4 is NOT alternative
+                                      (constructed witness, coordinate ≠ 0 by norm_num)
+
+  Formulation choice (reported for the record): the trilinearity hypotheses are
+  carried as an explicit `IsTrilinear` predicate (six add/smul laws), NOT wrapped
+  in Mathlib's `MultilinearMap`.  Rationale: the associator and its symmetrizations
+  are bare functions `CDAlg → CDAlg → CDAlg → CDAlg`; wrapping each in a bundled
+  `MultilinearMap (fun _ : Fin 3 => CDAlg R n) (CDAlg R n)` would force `Fin 3`
+  tuple-plumbing (`Matrix.cons`/`Fin.cons` updates) at every use site, whereas the
+  predicate form lets `simp only [assoc, mul_add_left, …]` discharge the six laws
+  directly.  The lift proof itself (expand each argument via `basis_expansion`,
+  push `T` through the three sums) is identical either way; the predicate keeps the
+  consumer-side boilerplate minimal.
+
+  Completeness: zero `sorry`, zero `native_decide`, zero vacuous `True`.
+  `#print axioms` audit at the bottom.
+-/
+import QBP.Foundations.CDAlg
+
+namespace QBP.Foundations.CDAlg
+
+variable {R : Type*} [CommRing R] {n : ℕ}
+
+/-! ## 1. Multilinearity predicates -/
+
+/-- `T` is `R`-bilinear: additive and `R`-homogeneous in each of its two slots. -/
+structure IsBilinear (T : CDAlg R n → CDAlg R n → CDAlg R n) : Prop where
+  add_left  : ∀ x x' y, T (x + x') y = T x y + T x' y
+  smul_left : ∀ (r : R) x y, T (r • x) y = r • T x y
+  add_right : ∀ x y y', T x (y + y') = T x y + T x y'
+  smul_right: ∀ (r : R) x y, T x (r • y) = r • T x y
+
+/-- `T` is `R`-trilinear: additive and `R`-homogeneous in each of its three slots. -/
+structure IsTrilinear (T : CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n) : Prop where
+  add_left  : ∀ x x' y z, T (x + x') y z = T x y z + T x' y z
+  smul_left : ∀ (r : R) x y z, T (r • x) y z = r • T x y z
+  add_mid   : ∀ x y y' z, T x (y + y') z = T x y z + T x y' z
+  smul_mid  : ∀ (r : R) x y z, T x (r • y) z = r • T x y z
+  add_right : ∀ x y z z', T x y (z + z') = T x y z + T x y z'
+  smul_right: ∀ (r : R) x y z, T x y (r • z) = r • T x y z
+
+/-- `T` is `R`-quadrilinear: additive and `R`-homogeneous in each of its four slots. -/
+structure IsQuadrilinear (T : CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n) :
+    Prop where
+  add_1  : ∀ w w' x y z, T (w + w') x y z = T w x y z + T w' x y z
+  smul_1 : ∀ (r : R) w x y z, T (r • w) x y z = r • T w x y z
+  add_2  : ∀ w x x' y z, T w (x + x') y z = T w x y z + T w x' y z
+  smul_2 : ∀ (r : R) w x y z, T w (r • x) y z = r • T w x y z
+  add_3  : ∀ w x y y' z, T w x (y + y') z = T w x y z + T w x y' z
+  smul_3 : ∀ (r : R) w x y z, T w x (r • y) z = r • T w x y z
+  add_4  : ∀ w x y z z', T w x y (z + z') = T w x y z + T w x y z'
+  smul_4 : ∀ (r : R) w x y z, T w x y (r • z) = r • T w x y z
+
+/-! ## 2. Distribution over `Finset.sum` -/
+
+theorem IsBilinear.sum_left {T : CDAlg R n → CDAlg R n → CDAlg R n} (hT : IsBilinear T)
+    {ι : Type*} (s : Finset ι) (f : ι → CDAlg R n) (y : CDAlg R n) :
+    T (∑ i ∈ s, f i) y = ∑ i ∈ s, T (f i) y := by
+  classical
+  induction s using Finset.induction with
+  | empty => simpa using (by have := hT.smul_left 0 0 y; simpa using this)
+  | insert a s ha ih => rw [Finset.sum_insert ha, hT.add_left, ih, Finset.sum_insert ha]
+
+theorem IsBilinear.sum_right {T : CDAlg R n → CDAlg R n → CDAlg R n} (hT : IsBilinear T)
+    {ι : Type*} (s : Finset ι) (x : CDAlg R n) (f : ι → CDAlg R n) :
+    T x (∑ i ∈ s, f i) = ∑ i ∈ s, T x (f i) := by
+  classical
+  induction s using Finset.induction with
+  | empty => simpa using (by have := hT.smul_right 0 x 0; simpa using this)
+  | insert a s ha ih => rw [Finset.sum_insert ha, hT.add_right, ih, Finset.sum_insert ha]
+
+theorem IsTrilinear.sum_left {T : CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n}
+    (hT : IsTrilinear T) {ι : Type*} (s : Finset ι) (f : ι → CDAlg R n) (y z : CDAlg R n) :
+    T (∑ i ∈ s, f i) y z = ∑ i ∈ s, T (f i) y z := by
+  classical
+  induction s using Finset.induction with
+  | empty => simpa using (by have := hT.smul_left 0 0 y z; simpa using this)
+  | insert a s ha ih => rw [Finset.sum_insert ha, hT.add_left, ih, Finset.sum_insert ha]
+
+theorem IsTrilinear.sum_mid {T : CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n}
+    (hT : IsTrilinear T) {ι : Type*} (s : Finset ι) (x : CDAlg R n) (f : ι → CDAlg R n)
+    (z : CDAlg R n) :
+    T x (∑ i ∈ s, f i) z = ∑ i ∈ s, T x (f i) z := by
+  classical
+  induction s using Finset.induction with
+  | empty => simpa using (by have := hT.smul_mid 0 x 0 z; simpa using this)
+  | insert a s ha ih => rw [Finset.sum_insert ha, hT.add_mid, ih, Finset.sum_insert ha]
+
+theorem IsTrilinear.sum_right {T : CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n}
+    (hT : IsTrilinear T) {ι : Type*} (s : Finset ι) (x y : CDAlg R n) (f : ι → CDAlg R n) :
+    T x y (∑ i ∈ s, f i) = ∑ i ∈ s, T x y (f i) := by
+  classical
+  induction s using Finset.induction with
+  | empty => simpa using (by have := hT.smul_right 0 x y 0; simpa using this)
+  | insert a s ha ih => rw [Finset.sum_insert ha, hT.add_right, ih, Finset.sum_insert ha]
+
+theorem IsQuadrilinear.sum_1 {T : CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n}
+    (hT : IsQuadrilinear T) {ι : Type*} (s : Finset ι) (f : ι → CDAlg R n) (x y z : CDAlg R n) :
+    T (∑ i ∈ s, f i) x y z = ∑ i ∈ s, T (f i) x y z := by
+  classical
+  induction s using Finset.induction with
+  | empty => simpa using (by have := hT.smul_1 0 0 x y z; simpa using this)
+  | insert a s ha ih => rw [Finset.sum_insert ha, hT.add_1, ih, Finset.sum_insert ha]
+
+theorem IsQuadrilinear.sum_2 {T : CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n}
+    (hT : IsQuadrilinear T) {ι : Type*} (s : Finset ι) (w : CDAlg R n) (f : ι → CDAlg R n)
+    (y z : CDAlg R n) :
+    T w (∑ i ∈ s, f i) y z = ∑ i ∈ s, T w (f i) y z := by
+  classical
+  induction s using Finset.induction with
+  | empty => simpa using (by have := hT.smul_2 0 w 0 y z; simpa using this)
+  | insert a s ha ih => rw [Finset.sum_insert ha, hT.add_2, ih, Finset.sum_insert ha]
+
+theorem IsQuadrilinear.sum_3 {T : CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n}
+    (hT : IsQuadrilinear T) {ι : Type*} (s : Finset ι) (w x : CDAlg R n) (f : ι → CDAlg R n)
+    (z : CDAlg R n) :
+    T w x (∑ i ∈ s, f i) z = ∑ i ∈ s, T w x (f i) z := by
+  classical
+  induction s using Finset.induction with
+  | empty => simpa using (by have := hT.smul_3 0 w x 0 z; simpa using this)
+  | insert a s ha ih => rw [Finset.sum_insert ha, hT.add_3, ih, Finset.sum_insert ha]
+
+theorem IsQuadrilinear.sum_4 {T : CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n}
+    (hT : IsQuadrilinear T) {ι : Type*} (s : Finset ι) (w x y : CDAlg R n) (f : ι → CDAlg R n) :
+    T w x y (∑ i ∈ s, f i) = ∑ i ∈ s, T w x y (f i) := by
+  classical
+  induction s using Finset.induction with
+  | empty => simpa using (by have := hT.smul_4 0 w x y 0; simpa using this)
+  | insert a s ha ih => rw [Finset.sum_insert ha, hT.add_4, ih, Finset.sum_insert ha]
+
+/-! ## 3. The lifting metalemmas
+
+A multilinear map vanishing on all basis tuples vanishes everywhere.  Proof:
+expand each argument by `basis_expansion`, push the map through each sum, conclude
+from the basis hypothesis. -/
+
+/-- A bilinear map vanishing on all basis pairs vanishes everywhere. -/
+theorem lift_bilinear_eq {T : CDAlg R n → CDAlg R n → CDAlg R n}
+    (hT : IsBilinear T) (hbasis : ∀ i j : Fin (2^n), T (e i) (e j) = 0)
+    (x y : CDAlg R n) : T x y = 0 := by
+  conv_lhs => rw [basis_expansion x, basis_expansion y]
+  rw [hT.sum_left]
+  refine Finset.sum_eq_zero (fun i _ => ?_)
+  rw [hT.smul_left, hT.sum_right, Finset.smul_sum]
+  refine Finset.sum_eq_zero (fun j _ => ?_)
+  rw [hT.smul_right, hbasis, smul_zero, smul_zero]
+
+/-- **KEYSTONE.**  A trilinear map vanishing on all basis triples vanishes
+    everywhere.  This is the bridge from `decide`-checked basis facts to
+    algebra-wide laws that the entire #474 program rests on. -/
+theorem lift_trilinear_eq {T : CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n}
+    (hT : IsTrilinear T) (hbasis : ∀ i j k : Fin (2^n), T (e i) (e j) (e k) = 0)
+    (x y z : CDAlg R n) : T x y z = 0 := by
+  conv_lhs => rw [basis_expansion x, basis_expansion y, basis_expansion z]
+  rw [hT.sum_left]
+  refine Finset.sum_eq_zero (fun i _ => ?_)
+  rw [hT.smul_left, hT.sum_mid, Finset.smul_sum]
+  refine Finset.sum_eq_zero (fun j _ => ?_)
+  rw [hT.smul_mid, hT.sum_right, smul_comm, Finset.smul_sum, Finset.smul_sum]
+  refine Finset.sum_eq_zero (fun k _ => ?_)
+  rw [hT.smul_right, hbasis, smul_zero, smul_zero, smul_zero]
+
+/-- A quadrilinear map vanishing on all basis 4-tuples vanishes everywhere.
+    (Powers the Moufang identities in PR-C1.) -/
+theorem lift_quadrilinear_eq {T : CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n → CDAlg R n}
+    (hT : IsQuadrilinear T)
+    (hbasis : ∀ i j k l : Fin (2^n), T (e i) (e j) (e k) (e l) = 0)
+    (w x y z : CDAlg R n) : T w x y z = 0 := by
+  conv_lhs => rw [basis_expansion w, basis_expansion x, basis_expansion y, basis_expansion z]
+  rw [hT.sum_1]
+  refine Finset.sum_eq_zero (fun i _ => ?_)
+  rw [hT.smul_1, hT.sum_2, Finset.smul_sum]
+  refine Finset.sum_eq_zero (fun j _ => ?_)
+  rw [hT.smul_2, hT.sum_3, smul_comm, Finset.smul_sum, Finset.smul_sum]
+  refine Finset.sum_eq_zero (fun k _ => ?_)
+  rw [hT.smul_3, hT.sum_4, smul_comm, Finset.smul_sum, Finset.smul_sum, Finset.smul_sum]
+  refine Finset.sum_eq_zero (fun l _ => ?_)
+  rw [hT.smul_4, hbasis, smul_zero, smul_zero, smul_zero, smul_zero]
+
+/-! ## 4. The associator and its trilinearity -/
+
+/-- The associator `[x,y,z] = (x·y)·z − x·(y·z)`.  Vanishes iff `(x,y,z)` associate. -/
+def assoc (x y z : CDAlg R n) : CDAlg R n := (x * y) * z - x * (y * z)
+
+/-- The associator is `R`-trilinear (from bilinearity of `*`). -/
+theorem assoc_trilinear : IsTrilinear (assoc : CDAlg R n → _ → _ → _) where
+  add_left x x' y z := by simp only [assoc, mul_add_left]; abel
+  smul_left r x y z := by simp only [assoc, mul_smul_left, smul_sub]
+  add_mid x y y' z := by simp only [assoc, mul_add_left, mul_add_right]; abel
+  smul_mid r x y z := by simp only [assoc, mul_smul_left, mul_smul_right, smul_sub]
+  add_right x y z z' := by simp only [assoc, mul_add_right]; abel
+  smul_right r x y z := by simp only [assoc, mul_smul_right, smul_sub]
+
+/-- The associator on basis elements: `[eᵢ, e_j, e_k] = assocCoeffZ • e_{i⊕j⊕k}`,
+    where the integer coefficient is the basis associator. -/
+def assocCoeffZ (n : ℕ) (i j k : Fin (2^n)) : Int :=
+  mulCoeff n i j * mulCoeff n (i ^^^ j) k - mulCoeff n j k * mulCoeff n i (j ^^^ k)
+
+theorem assoc_e (i j k : Fin (2^n)) :
+    (assoc (e i) (e j) (e k) : CDAlg R n)
+      = (assocCoeffZ n i j k : R) • e (i ^^^ j ^^^ k) := by
+  have hxor : (i ^^^ j ^^^ k : Fin (2^n)) = (i ^^^ (j ^^^ k) : Fin (2^n)) := by
+    apply Fin.ext
+    simp only [Fin.xor_val_of_two_pow, Nat.xor_assoc]
+  simp only [assoc, e_mul_e, mul_smul_left, mul_smul_right, smul_smul]
+  rw [assocCoeffZ, hxor]
+  push_cast
+  rw [sub_smul, mul_comm (mulCoeff n j k : R)]
+
+/-! ## 5. Octonion alternativity payoff (𝕆 = CDAlg ℝ 3) -/
+
+/-- Polarized-left-alternativity map `[x,y,z] + [y,x,z]`, trilinear. -/
+def laMap (x y z : CDAlg R n) : CDAlg R n := assoc x y z + assoc y x z
+
+theorem laMap_trilinear : IsTrilinear (laMap : CDAlg R n → _ → _ → _) where
+  add_left x x' y z := by
+    simp only [laMap, assoc_trilinear.add_left, assoc_trilinear.add_mid]; abel
+  smul_left r x y z := by
+    simp only [laMap, assoc_trilinear.smul_left, assoc_trilinear.smul_mid, smul_add]
+  add_mid x y y' z := by
+    simp only [laMap, assoc_trilinear.add_mid, assoc_trilinear.add_left]; abel
+  smul_mid r x y z := by
+    simp only [laMap, assoc_trilinear.smul_mid, assoc_trilinear.smul_left, smul_add]
+  add_right x y z z' := by
+    simp only [laMap, assoc_trilinear.add_right]; abel
+  smul_right r x y z := by
+    simp only [laMap, assoc_trilinear.smul_right, smul_add]
+
+/-- Polarized-right-alternativity map `[x,y,z] + [x,z,y]`, trilinear. -/
+def raMap (x y z : CDAlg R n) : CDAlg R n := assoc x y z + assoc x z y
+
+theorem raMap_trilinear : IsTrilinear (raMap : CDAlg R n → _ → _ → _) where
+  add_left x x' y z := by
+    simp only [raMap, assoc_trilinear.add_left]; abel
+  smul_left r x y z := by
+    simp only [raMap, assoc_trilinear.smul_left, smul_add]
+  add_mid x y y' z := by
+    simp only [raMap, assoc_trilinear.add_mid, assoc_trilinear.add_right]; abel
+  smul_mid r x y z := by
+    simp only [raMap, assoc_trilinear.smul_mid, assoc_trilinear.smul_right, smul_add]
+  add_right x y z z' := by
+    simp only [raMap, assoc_trilinear.add_right, assoc_trilinear.add_mid]; abel
+  smul_right r x y z := by
+    simp only [raMap, assoc_trilinear.smul_right, assoc_trilinear.smul_mid, smul_add]
+
+/-- **Integer basis fact (kernel `decide`).**  The octonion associator is
+    left-alternating on all 8³ = 512 basis triples. -/
+theorem octonion_assocCoeffZ_left_alt :
+    ∀ i j k : Fin (2^3), assocCoeffZ 3 i j k + assocCoeffZ 3 j i k = 0 := by decide
+
+/-- **Integer basis fact (kernel `decide`).**  The octonion associator is
+    right-alternating on all basis triples. -/
+theorem octonion_assocCoeffZ_right_alt :
+    ∀ i j k : Fin (2^3), assocCoeffZ 3 i j k + assocCoeffZ 3 i k j = 0 := by decide
+
+theorem octonion_laMap_basis (i j k : Fin (2^3)) :
+    (laMap (e i) (e j) (e k) : CDAlg ℝ 3) = 0 := by
+  rw [laMap, assoc_e, assoc_e]
+  have h1 : (j ^^^ i ^^^ k : Fin (2^3)) = (i ^^^ j ^^^ k : Fin (2^3)) := by
+    apply Fin.ext; simp only [Fin.xor_val_of_two_pow]; rw [Nat.xor_comm i.val j.val]
+  rw [h1, ← add_smul]
+  rw [show ((assocCoeffZ 3 i j k : ℝ) + (assocCoeffZ 3 j i k : ℝ))
+        = (((assocCoeffZ 3 i j k + assocCoeffZ 3 j i k : Int)) : ℝ) by push_cast; ring,
+     octonion_assocCoeffZ_left_alt i j k]
+  simp
+
+theorem octonion_raMap_basis (i j k : Fin (2^3)) :
+    (raMap (e i) (e j) (e k) : CDAlg ℝ 3) = 0 := by
+  rw [raMap, assoc_e, assoc_e]
+  have h1 : (i ^^^ k ^^^ j : Fin (2^3)) = (i ^^^ j ^^^ k : Fin (2^3)) := by
+    apply Fin.ext; simp only [Fin.xor_val_of_two_pow]
+    rw [Nat.xor_assoc, Nat.xor_assoc, Nat.xor_comm k.val j.val]
+  rw [h1, ← add_smul]
+  rw [show ((assocCoeffZ 3 i j k : ℝ) + (assocCoeffZ 3 i k j : ℝ))
+        = (((assocCoeffZ 3 i j k + assocCoeffZ 3 i k j : Int)) : ℝ) by push_cast; ring,
+     octonion_assocCoeffZ_right_alt i j k]
+  simp
+
+/-- **Octonion left-alternativity, polarized form** (lifted from the basis fact):
+    for all `x y z : CDAlg ℝ 3`, `[x,y,z] + [y,x,z] = 0`. -/
+theorem octonion_left_alternative_polarized (x y z : CDAlg ℝ 3) :
+    assoc x y z + assoc y x z = 0 :=
+  lift_trilinear_eq laMap_trilinear octonion_laMap_basis x y z
+
+/-- **Octonion right-alternativity, polarized form** (lifted): `[x,y,z] + [x,z,y] = 0`. -/
+theorem octonion_right_alternative_polarized (x y z : CDAlg ℝ 3) :
+    assoc x y z + assoc x z y = 0 :=
+  lift_trilinear_eq raMap_trilinear octonion_raMap_basis x y z
+
+theorem assoc_diag_left (x y : CDAlg ℝ 3) : assoc x x y = 0 := by
+  have h2 : (2 : ℝ) • assoc x x y = 0 := by
+    rw [two_smul]; exact octonion_left_alternative_polarized x x y
+  rcases smul_eq_zero.mp h2 with hz | hz
+  · exact absurd hz two_ne_zero
+  · exact hz
+
+theorem assoc_diag_right (x y : CDAlg ℝ 3) : assoc x y y = 0 := by
+  have h2 : (2 : ℝ) • assoc x y y = 0 := by
+    rw [two_smul]; exact octonion_right_alternative_polarized x y y
+  rcases smul_eq_zero.mp h2 with hz | hz
+  · exact absurd hz two_ne_zero
+  · exact hz
+
+/-- **PAYOFF: octonion alternativity.**  𝕆 = `CDAlg ℝ 3` is left- and
+    right-alternative: for all `x y`, `(x·x)·y = x·(x·y)` and `(x·y)·y = x·(y·y)`.
+    Proven via the trilinear lift (`lift_trilinear_eq`) + the basis facts
+    `octonion_assocCoeffZ_{left,right}_alt` — the basis-vs-algebra-wide honesty gap
+    closed by the keystone, not asserted. -/
+theorem octonion_alternative (x y : CDAlg ℝ 3) :
+    (x * x) * y = x * (x * y) ∧ (x * y) * y = x * (y * y) := by
+  refine ⟨?_, ?_⟩
+  · have := assoc_diag_left x y; rwa [assoc, sub_eq_zero] at this
+  · have := assoc_diag_right x y; rwa [assoc, sub_eq_zero] at this
+
+/-! ## 6. Sedenion non-alternativity counterexample (𝕊 = CDAlg ℝ 4)
+
+A constructed witness: `x = e₁ + e₁₀`, `y = e₄`.  The associator `[x, x, y]` has a
+nonzero coordinate (index 15), so `(x·x)·y ≠ x·(x·y)`.  The nonzeroness is by
+`norm_num` on that ℝ-coordinate — NOT a named witness in a comment. -/
+
+/-- The sedenion witness `x = e₁ + e₁₀`. -/
+def sedWitX : CDAlg ℝ 4 := e ⟨1, by norm_num⟩ + e ⟨10, by norm_num⟩
+/-- The sedenion witness `y = e₄`. -/
+def sedWitY : CDAlg ℝ 4 := e ⟨4, by norm_num⟩
+
+/-- The integer associator coefficient `assocCoeffZ 4 1 10 4 = 2 ≠ 0` (kernel
+    `decide`): this is the seed of the sedenion non-alternativity witness. -/
+theorem sed_assocCoeffZ_witness :
+    assocCoeffZ 4 ⟨1, by norm_num⟩ ⟨10, by norm_num⟩ ⟨4, by norm_num⟩ = 2 := by decide
+
+/-- **PAYOFF: sedenions are NOT alternative.**  𝕊 = `CDAlg ℝ 4` fails left
+    alternativity: there exist `x y` with `(x·x)·y ≠ x·(x·y)`.  Witnessed by
+    `x = e₁ + e₁₀`, `y = e₄`, whose associator has coordinate 2 (≠ 0) at index 15. -/
+theorem sedenion_not_alternative :
+    ∃ x y : CDAlg ℝ 4, (x * x) * y ≠ x * (x * y) := by
+  refine ⟨sedWitX, sedWitY, ?_⟩
+  intro hcontra
+  -- the associator [x,x,y] = (x*x)*y - x*(x*y) would then be 0
+  have hzero : assoc sedWitX sedWitX sedWitY = 0 := by
+    rw [assoc, hcontra, sub_self]
+  -- but its coordinate at index 15 is 2 ≠ 0.  Expand by trilinearity into the four
+  -- basis associators, each evaluated by `assoc_e`.
+  set i1 : Fin (2^4) := ⟨1, by norm_num⟩
+  set i10 : Fin (2^4) := ⟨10, by norm_num⟩
+  set i4 : Fin (2^4) := ⟨4, by norm_num⟩
+  have hexp : assoc sedWitX sedWitX sedWitY
+      = assoc (e i1) (e i1) (e i4) + assoc (e i1) (e i10) (e i4)
+        + (assoc (e i10) (e i1) (e i4) + assoc (e i10) (e i10) (e i4)) := by
+    rw [sedWitX, sedWitY, assoc_trilinear.add_left, assoc_trilinear.add_mid,
+      assoc_trilinear.add_mid]
+  have h15 : (⟨15, by norm_num⟩ : Fin (2^4)) = i1 ^^^ i10 ^^^ i4 := by decide
+  have hcoord : (assoc sedWitX sedWitX sedWitY).coord ⟨15, by norm_num⟩ = 2 := by
+    rw [hexp]
+    simp only [assoc_e, add_coord, smul_coord, e_coord]
+    have e1 : assocCoeffZ 4 i1 i1 i4 = 0 := by decide
+    have e2 : assocCoeffZ 4 i1 i10 i4 = 2 := by decide
+    have e3 : assocCoeffZ 4 i10 i1 i4 = 0 := by decide
+    have e4 : assocCoeffZ 4 i10 i10 i4 = 0 := by decide
+    have x1 : (i1 ^^^ i1 ^^^ i4 : Fin (2^4)) = i4 := by decide
+    have x2 : (i1 ^^^ i10 ^^^ i4 : Fin (2^4)) = ⟨15, by norm_num⟩ := by decide
+    have x3 : (i10 ^^^ i1 ^^^ i4 : Fin (2^4)) = ⟨15, by norm_num⟩ := by decide
+    have x4 : (i10 ^^^ i10 ^^^ i4 : Fin (2^4)) = i4 := by decide
+    rw [e1, e2, e3, e4, x1, x2, x3, x4]
+    norm_num [i4]
+  rw [hzero] at hcoord
+  simp only [zero_coord] at hcoord
+  norm_num at hcoord
+
+/-! ## 7. Completeness audit — `#print axioms` -/
+
+#print axioms lift_bilinear_eq
+#print axioms lift_trilinear_eq
+#print axioms lift_quadrilinear_eq
+#print axioms assoc_trilinear
+#print axioms octonion_alternative
+#print axioms octonion_left_alternative_polarized
+#print axioms octonion_right_alternative_polarized
+#print axioms sedenion_not_alternative
+
+end QBP.Foundations.CDAlg


### PR DESCRIPTION
## Summary

Wave-1 keystone of the Phase-1 plan (#474 staging comment): the ring-generic Cayley-Dickson carrier and the multilinear lifting layer that upgrades basis-level `decide` facts into honest **algebra-wide** theorems — retiring the O1a basis-caveat class permanently.

| File | Contents |
|---|---|
| `CDAlg.lean` | `CDAlg R n` (coord : Fin (2^n) → R), Module/Mul instances (never `Ring` at 𝕆/𝕊), `mulCoeff` by CD recursion + **kernel-checked agreement with the existing verified tables** (`mulCoeff_four_eq_sgnTable` 256-pair decide; `mulCoeff_three_eq_fano`), structural lemmas by induction on n, **quadraticity `cdAlg_sq_eq` proven for general n** (stronger than spec; powers PR-F exp/log) |
| `CDLifting.lean` | `lift_bilinear_eq` / **`lift_trilinear_eq` (keystone)** / `lift_quadrilinear_eq` (Moufang-ready), associator trilinearity, and the payoff demonstrations |

### Payoff demonstrations (the architecture validated end-to-end)

```lean
theorem octonion_alternative (x y : CDAlg ℝ 3) :
    (x * x) * y = x * (x * y) ∧ (x * y) * y = x * (y * y)   -- genuine ∀, no basis caveat

theorem sedenion_not_alternative :
    ∃ x y : CDAlg ℝ 4, (x * x) * y ≠ x * (x * y)            -- witnessed term (x=e₁+e₁₀, y=e₄)
```

Design note for reviewers: alternativity's `(xx)y = x(xy)` is quadratic in x — NOT trilinear — so the proof lifts the **polarized** form `[x,y,z]+[y,x,z]=0` (genuinely trilinear, basis-decided over ℤ) and specializes at the diagonal (char ≠ 2). This is the mathematically forced route and the reason `lift_trilinear_eq` is the right keystone. Trilinearity carried as an explicit `IsTrilinear` predicate rather than Mathlib `MultilinearMap` (consumer-side simp ergonomics; rationale in file).

## Theory-element headline: three-way evidence comparison

N/A — pure-math foundation infrastructure; no physical claim is made, so the experimental/QBP/PhysLean three-way comparison is not applicable (per template rule, reason stated).

## CTH anchor impact (per `docs/workflows/review_anchoring.md`)

- **New anchors minted:** none in this PR — anchor batches for #474 matrix rows are emitted per-row at row completion under the confluent-trust#96 protocol (ratified); this PR is infrastructure.
- **Anchors revised / retired:** none.
- **Anchor-rule terminations:**
  - [x] Lean file:line — all theorems in `CDAlg.lean` / `CDLifting.lean`, axioms ⊆ {propext, Classical.choice, Quot.sound}
- **Routing axis:**
  - [x] theory-axis → co-sign by @qbp-oppenheimer (orchestrating persona)
  - [ ] schema-axis / [ ] two-axis / [ ] N/A

## Mechanical verification evidence (links, not assertions)

- [x] `lake build QBP` green from scratch — 3127 jobs (CI confirms from clean checkout)
- [x] `check_lean_foundations.py` PASSED at 0/0; `check_layer_imports.py` clean (aggregator wired)
- [x] `#print axioms` on every theorem: exactly `[propext, Classical.choice, Quot.sound]`
- [x] Zero sorry / native_decide / vacuous-True (grep verified; words appear only in doc-comments)
- [x] CI green on this PR — 14/14 checks; canonical evidence: the notifier's ALL-GREEN verdict comment @ 2026-06-05 16:49 UTC (`45503a0`, ✔️ reviews stamped for this exact head)

## Effort calibration delivered for PR-C1 (Moufang)

`lift_quadrilinear_eq` already proven (mechanical 4-arg copy). C1's real cost = three `IsQuadrilinear` instances + one 4096-case ℤ-decide per Moufang identity.

Part of #474 (Wave 1). Refs #476/#477 (consumers), qbp-compute-unit#59 (export shape: `mulCoeff 3` + agreement lemmas = the theorem-backed ground truth, per bridge seq 522/523).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
