### PR TITLE
[infra] link-check: ignore flaky webaim.org (recurring CI timeout)

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -5,9 +5,17 @@
     },
     {
       "pattern": "^https://rewind\\.com"
+    },
+    {
+      "pattern": "^https://webaim\\.org"
     }
   ],
-  "aliveStatusCodes": [200, 206, 403, 502],
+  "aliveStatusCodes": [
+    200,
+    206,
+    403,
+    502
+  ],
   "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "5s"


### PR DESCRIPTION
Two webaim.org links (valid in browsers; slow host) intermittently ESOCKETTIMEDOUT from CI runners — failed master `a1a3e7cf` and PR #513's repo-wide sweep. Same remedy as the existing rewind.com entry.

## Mechanical verification evidence
- [x] JSON valid (loaded+rewritten via python json)
- [ ] CI green (link-check itself validates the config)

## CTH anchor impact
- [x] N/A — CI config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)