### PR TITLE
[infra] notifier: exit-127 fix + API PR-resolution + failure visibility

### DIFF
--- a/.github/workflows/pr-check-status.yml
+++ b/.github/workflows/pr-check-status.yml
@@ -143,15 +143,29 @@ jobs:
 
           # PR resolution: payload first, API fallback (payload pull_requests[]
           # is unreliable — empty for real same-repo PRs; observed on #512).
+          # EXACT head-SHA match only (review #517 blocking #1): the endpoint
+          # returns every open PR whose branch CONTAINS the commit, so a loose
+          # `first` can post the verdict to the wrong PR in stacked branches.
+          # Verdicts are per-head — a SHA that heads no open PR gets none.
           if [ -z "${PR:-}" ]; then
             PR=$(gh api "repos/$REPO/commits/$SHA/pulls" \
-                 --jq '[.[] | select(.state == "open")] | (first // {}) | .number // empty')
+                 --jq '[.[] | select(.state == "open" and .head.sha == "'"$SHA"'")] | (first // {}) | .number // empty')
           fi
           if [ -z "${PR:-}" ]; then
-            echo "no open PR found for $SHA — not a PR head; nothing to do."
+            echo "no open PR headed by $SHA — nothing to do."
             exit 0
           fi
-          echo "resolved PR #$PR for $SHA"
+          # Stale-verdict guard (review #517 blocking #2): per-SHA concurrency
+          # means an old-SHA run is not cancelled by a new push; without this
+          # guard it could PATCH the marker comment with an outdated verdict
+          # AFTER the correct one. If the PR head has advanced past our event
+          # SHA, this run is history — exit.
+          HEADNOW=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
+          if [ "$HEADNOW" != "$SHA" ]; then
+            echo "stale event: PR #$PR head is $HEADNOW, event SHA $SHA — exiting."
+            exit 0
+          fi
+          echo "resolved PR #$PR for $SHA (current head)"
           # review-completeness gates excluded from TECH-GREEN (they cannot be
           # green before reviews exist — the deadlock this design dissolves).
           # Single source of truth for the excluded list:
@@ -248,7 +262,10 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -u
+          # exact head-SHA match, same rule as the main resolver (review #517)
           PR=$(gh api "repos/$REPO/commits/$SHA/pulls" \
-               --jq '[.[] | select(.state == "open")] | (first // {}) | .number // empty' || true)
+               --jq '[.[] | select(.state == "open" and .head.sha == "'"$SHA"'")] | (first // {}) | .number // empty' || true)
           [ -z "${PR:-}" ] && { echo "no PR to warn"; exit 0; }
-          gh pr comment "$PR" --repo "$REPO" --body "⚠️ **pr-check-status notifier ERRORED** on \\\`$SHA\\\` — no verdict was posted for this head. Check the run: $RUN_URL. Do not trust any older verdict comment above." || true
+          # single-quoted printf — no hand-escaped backticks anywhere (127 class)
+          WARN=$(printf '⚠️ **pr-check-status notifier ERRORED** on `%s` — no verdict was posted for this head. Check the run: %s. Do not trust any older verdict comment above.' "$SHA" "$RUN_URL")
+          gh pr comment "$PR" --repo "$REPO" --body "$WARN" || true

--- a/.github/workflows/pr-check-status.yml
+++ b/.github/workflows/pr-check-status.yml
@@ -113,9 +113,15 @@ jobs:
     # IMPORTANT: this job name is the notifier's own check-run name; the query
     # below excludes it by name (self-counting fix, #508 review finding #1).
     name: pr-check-status-notify
-    if: ${{ (github.event_name == 'check_suite' && github.event.check_suite.pull_requests[0] != null) || (github.event_name == 'workflow_run' && github.event.workflow_run.pull_requests[0] != null) }}
+    # Fire on any suite/run completion that carries a head SHA; the PR is
+    # resolved via API inside the job. The event payload's pull_requests[] is
+    # NOT trusted: GitHub populates it unreliably (observed empty for real
+    # same-repo PR #512 → the notifier silently skipped a red verdict).
+    if: ${{ github.event_name == 'check_suite' || github.event_name == 'workflow_run' }}
     concurrency:
-      group: pr-notify-${{ github.event.check_suite.pull_requests[0].number || github.event.workflow_run.pull_requests[0].number }}
+      # group by SHA (PR number unavailable pre-resolution); same-PR pushes get
+      # fresh groups per SHA — acceptable, the upsert is idempotent per comment
+      group: pr-notify-${{ github.event.check_suite.head_sha || github.event.workflow_run.head_sha }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
@@ -134,6 +140,18 @@ jobs:
           set -euo pipefail
           MARKER="<!-- pr-check-status-notifier -->"
           SELF="pr-check-status-notify"
+
+          # PR resolution: payload first, API fallback (payload pull_requests[]
+          # is unreliable — empty for real same-repo PRs; observed on #512).
+          if [ -z "${PR:-}" ]; then
+            PR=$(gh api "repos/$REPO/commits/$SHA/pulls" \
+                 --jq '[.[] | select(.state == "open")] | (first // {}) | .number // empty')
+          fi
+          if [ -z "${PR:-}" ]; then
+            echo "no open PR found for $SHA — not a PR head; nothing to do."
+            exit 0
+          fi
+          echo "resolved PR #$PR for $SHA"
           # review-completeness gates excluded from TECH-GREEN (they cannot be
           # green before reviews exist — the deadlock this design dissolves).
           # Single source of truth for the excluded list:
@@ -179,10 +197,14 @@ jobs:
             LASTREV=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" --paginate \
                       --jq '[.[] | .body]' | jq -s 'add // []' \
                       | jq -r '[.[] | capture("<!-- reviewed-sha: (?<s>[0-9a-f]{7,40}) -->").s] | last // empty')
-            FRESH="⚠️ review freshness UNVERIFIABLE — no `reviewed-sha` marker found in review comments; confirm reviews cover this head before merging."
+            # NOTE: FRESH strings are built with single-quoted printf formats
+            # ONLY — markdown backticks inside double-quoted bash are command
+            # substitution (the exit-127 incident: bash tried to EXECUTE
+            # `reviewed-sha` at the notifier's first live ALL-GREEN).
+            FRESH=$(printf '⚠️ review freshness UNVERIFIABLE — no `reviewed-sha` marker found in review comments; confirm reviews cover this head before merging.')
             if [ -n "$LASTREV" ]; then
               if [ "$LASTREV" = "$SHA" ]; then
-                FRESH="✔️ reviews stamped for this exact head."
+                FRESH=$(printf '✔️ reviews stamped for this exact head.')
               else
                 # patch-id comparison: identical content (rebase / empty
                 # retrigger commits) keeps reviews fresh; content change
@@ -194,9 +216,9 @@ jobs:
                 P_HEAD=$(pid "$SHA" || echo head-err)
                 P_REV=$(pid "$LASTREV" || echo rev-err)
                 if [ -n "$P_HEAD" ] && [ "$P_HEAD" = "$P_REV" ]; then
-                  FRESH="✔️ reviews stamped for \`$LASTREV\`; patch-id identical to head (cosmetic motion only — rebase/retrigger). Reviews remain fresh."
+                  FRESH=$(printf '✔️ reviews stamped for `%s`; patch-id identical to head (cosmetic motion only — rebase/retrigger). Reviews remain fresh.' "$LASTREV")
                 else
-                  FRESH="🔶 **DELTA ROUND REQUIRED** — reviews stamped for \`$LASTREV\` but the diff content has changed since (patch-id mismatch). Do not merge on these reviews."
+                  FRESH=$(printf '🔶 **DELTA ROUND REQUIRED** — reviews stamped for `%s` but the diff content has changed since (patch-id mismatch). Do not merge on these reviews.' "$LASTREV")
                 fi
               fi
             fi
@@ -214,3 +236,19 @@ jobs:
             gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$BODY" > /dev/null
             echo "created comment"
           fi
+      # Who watches the watcher: a notifier crash must never be silent (the
+      # exit-127 incident produced no verdict and no visible signal anywhere
+      # except a failed Actions run nobody was reading).
+      - name: Report notifier failure on the PR
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.check_suite.head_sha || github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -u
+          PR=$(gh api "repos/$REPO/commits/$SHA/pulls" \
+               --jq '[.[] | select(.state == "open")] | (first // {}) | .number // empty' || true)
+          [ -z "${PR:-}" ] && { echo "no PR to warn"; exit 0; }
+          gh pr comment "$PR" --repo "$REPO" --body "⚠️ **pr-check-status notifier ERRORED** on \\\`$SHA\\\` — no verdict was posted for this head. Check the run: $RUN_URL. Do not trust any older verdict comment above." || true


### PR DESCRIPTION
## Summary

The notifier's first production outage, root-caused and triple-fixed. Impact of the outage: PR #512's red link-check got **no verdict comment**, silently breaking the "everything resolved → beekeeper reviews" contract — the beekeeper found it by reading raw check states, which is exactly the failure mode this workflow exists to prevent.

| Bug | Root cause | Fix |
|---|---|---|
| **exit-127 crash** at the first live ALL-GREEN (#515's suites, run 26992022640) | markdown backticks inside double-quoted bash = command substitution — bash tried to execute `reviewed-sha` as a program. `bash -n` can't catch it (valid syntax, wrong semantics); reviews couldn't catch it (the ALL-GREEN path only runs post-merge) | all FRESH strings via single-quoted `printf`; **bug-class audit script run across the whole workflow: CLEAN** |
| **silent skip on #512** | `if:` trusted `workflow_run.pull_requests[]`, which GitHub populates unreliably (empty for a real same-repo PR) | job fires on any suite/run completion; PR resolved via `commits/{sha}/pulls` API (payload as fast path); exits quietly only when the SHA genuinely heads no open PR |
| **silent failure mode itself** | a crashed notifier produced no signal anywhere a human looks | `if: failure()` step posts a warning comment on the PR naming the failed run — who-watches-the-watcher |

## Process note (for the record)

#511's own test plan deferred the live test to "the next PR after merge" — and the next PR demonstrated both bugs. Deferred-live-test-as-informal-intention is the same defect class as PATTERN-01; the failure-visibility step is the structural answer (the system now reports its own outages), and post-merge verification on the NEXT PR is a checklist item in this PR's plan, not an intention.

## Mechanical verification evidence

- [x] YAML valid; embedded bash `bash -n` clean
- [x] backtick-in-double-quote audit: CLEAN (script in PR description history)
- [ ] CI green on this PR
- [ ] Post-merge live test on the next active PR: verdict comment appears; failure step exercised by observation window

## CTH anchor impact
- [x] N/A — CI workflow only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)