### PR TITLE
[infra] pending-upgrade guard — closed unblocking issue forces the owed upgrade

### DIFF
--- a/.github/workflows/lean-foundations.yml
+++ b/.github/workflows/lean-foundations.yml
@@ -23,8 +23,6 @@ on:
       - 'proofs/QBP/Foundations/.lean-gate-baseline.json'
       - 'scripts/check_lean_foundations.py'
       - 'scripts/check_layer_imports.py'
-      - 'scripts/check_pending_upgrades.py'
-      - 'docs/foundations/pending-upgrades.md'
       - '.github/workflows/lean-foundations.yml'
 
 permissions:
@@ -43,10 +41,6 @@ jobs:
         run: python3 scripts/check_lean_foundations.py --dir proofs/QBP/Foundations
       - name: Enforce layer-import DAG + aggregator completeness
         run: python3 scripts/check_layer_imports.py
-      - name: Pending-upgrade guard (closed unblocking issue ⇒ owed upgrade must land)
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: python3 scripts/check_pending_upgrades.py
 
   lake-build:
     name: lake build (zero errors)

--- a/.github/workflows/lean-foundations.yml
+++ b/.github/workflows/lean-foundations.yml
@@ -23,6 +23,8 @@ on:
       - 'proofs/QBP/Foundations/.lean-gate-baseline.json'
       - 'scripts/check_lean_foundations.py'
       - 'scripts/check_layer_imports.py'
+      - 'scripts/check_pending_upgrades.py'
+      - 'docs/foundations/pending-upgrades.md'
       - '.github/workflows/lean-foundations.yml'
 
 permissions:
@@ -41,6 +43,10 @@ jobs:
         run: python3 scripts/check_lean_foundations.py --dir proofs/QBP/Foundations
       - name: Enforce layer-import DAG + aggregator completeness
         run: python3 scripts/check_layer_imports.py
+      - name: Pending-upgrade guard (closed unblocking issue ⇒ owed upgrade must land)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/check_pending_upgrades.py
 
   lake-build:
     name: lake build (zero errors)

--- a/.github/workflows/pending-upgrades.yml
+++ b/.github/workflows/pending-upgrades.yml
@@ -1,0 +1,30 @@
+# Pending-upgrade guard — runs on EVERY PR (review #526 probe-6).
+#
+# The guard must trip on ANY pull request once a registered unblocking issue
+# closes — not only on foundations-touching PRs. A foundations-scoped trigger
+# would let the owed upgrade be skipped by any non-foundations PR merging first,
+# undercutting the "un-skippable the moment #NNN closes" guarantee. So it lives
+# in its own all-paths workflow.
+name: Pending-upgrade guard
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  issues: read        # gh issue view — explicit (review #526 probe-7: survives
+                      # the repo ever going private; not inherited from contents)
+
+jobs:
+  pending-upgrades:
+    name: Pending-upgrade guard (closed unblocking issue ⇒ owed upgrade must land)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Enforce pending-upgrade register
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/check_pending_upgrades.py

--- a/docs/foundations/pending-upgrades.md
+++ b/docs/foundations/pending-upgrades.md
@@ -1,0 +1,25 @@
+# Pending Upgrades Register
+
+Tracks deliverables that are **conditionally complete** — an acceptance-criterion
+cell or claim ruled MET for now, but with a known enhancement owed once a named
+unblocking issue lands. The companion CI guard (`scripts/check_pending_upgrades.py`)
+**fails the build when an unblocking issue here is CLOSED but its row is still
+`status: pending`** — converting "we'll update it later" from a memory-dependent
+promise into a mechanical merge-gate. (PATTERN-01 lesson: promises-to-update rot;
+only an un-mergeable state holds.)
+
+## How to resolve a row when its unblocking issue closes
+
+1. Apply the upgrade the row describes (the AC cell / annotation / doc edit).
+2. Change the row's `status:` from `pending` to `resolved` (keep the row as a
+   forensic record — mark, don't delete), or delete the row if the register entry
+   itself was the only artifact.
+3. CI goes green again.
+
+## Register
+
+<!-- one row per pending upgrade; the guard parses: issue: #N | status: pending|resolved -->
+
+| item | ruled | upgrade owed | unblocking issue | status |
+|---|---|---|---|---|
+| #474 AC6 exp/log cell | MET-pending (beekeeper, 2026-06-08) — exp total + log on dense domain + exp∘log=id clears "well-defined"; full-ℝ group law & left-inverse are enhancements | flip AC6 exp/log cell pending→full in #474 tracking + matrix index (PR-G) annotation | issue: #525 | status: pending |

--- a/scripts/check_pending_upgrades.py
+++ b/scripts/check_pending_upgrades.py
@@ -33,8 +33,14 @@ REGISTER = (
 ROW_RE = re.compile(r"issue:\s*#(\d+)\s*\|\s*status:\s*(pending|resolved)", re.I)
 
 
-def gh_issue_state(num: str) -> str | None:
-    """OPEN / CLOSED, or None if gh can't answer."""
+def gh_issue_state(num: str) -> str:
+    """OPEN / CLOSED / NOT_FOUND / TRANSIENT.
+
+    Distinguishes a genuinely-missing issue (a typo'd register number — must be
+    a loud violation, else the row silently never guards: the exact silent-rot
+    this whole guard exists to kill, review #526 probe-5) from a transient gh
+    failure (network/auth — lenient, CI is authoritative).
+    """
     try:
         out = subprocess.run(
             ["gh", "issue", "view", num, "--json", "state", "--jq", ".state"],
@@ -43,10 +49,14 @@ def gh_issue_state(num: str) -> str | None:
             timeout=30,
         )
     except (OSError, subprocess.SubprocessError):
-        return None
-    if out.returncode != 0:
-        return None
-    return out.stdout.strip().upper() or None
+        return "TRANSIENT"
+    if out.returncode == 0:
+        return out.stdout.strip().upper() or "TRANSIENT"
+    # gh ran but failed — is it "no such issue" (typo, our fault) or infra?
+    err = (out.stderr or "").lower()
+    if "could not resolve" in err or "not found" in err or "no issue" in err:
+        return "NOT_FOUND"
+    return "TRANSIENT"
 
 
 def main() -> int:
@@ -65,9 +75,14 @@ def main() -> int:
     violations: list[str] = []
     for num in pending:
         state = gh_issue_state(num)
-        if state is None:
-            print(
-                f"  #{num}: state UNKNOWN (gh could not resolve) — not failing on this"
+        if state == "TRANSIENT":
+            print(f"  #{num}: gh transient failure — lenient (CI authoritative)")
+            continue
+        if state == "NOT_FOUND":
+            violations.append(
+                f"#{num} does not exist — a pending register row points at a "
+                f"non-existent issue (typo?). A row that can never resolve is "
+                f"silent-rot; fix the number or remove the row"
             )
             continue
         if state == "CLOSED":

--- a/scripts/check_pending_upgrades.py
+++ b/scripts/check_pending_upgrades.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Pending-upgrade guard.
+
+Reads docs/foundations/pending-upgrades.md, finds every register row tagged
+`status: pending` with an `issue: #N`, and queries that issue's state via `gh`.
+FAILS (exit 1) if any pending row's unblocking issue is CLOSED — the owed
+upgrade must be applied and the row marked `resolved` before the build is green.
+
+This converts "met-pending" rulings from memory-dependent promises into a
+mechanical merge-gate: a closed unblocking issue with an un-resolved row cannot
+ship (PATTERN-01 — only an un-mergeable state holds).
+
+Skips gracefully (exit 0, loud note) if `gh` is unavailable / unauthenticated,
+so it never blocks a local commit on missing credentials — CI is the
+authoritative run (same posture as the differential guard, #504).
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REGISTER = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "foundations"
+    / "pending-upgrades.md"
+)
+# a register row: ... | issue: #123 | status: pending |
+ROW_RE = re.compile(r"issue:\s*#(\d+)\s*\|\s*status:\s*(pending|resolved)", re.I)
+
+
+def gh_issue_state(num: str) -> str | None:
+    """OPEN / CLOSED, or None if gh can't answer."""
+    try:
+        out = subprocess.run(
+            ["gh", "issue", "view", num, "--json", "state", "--jq", ".state"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.strip().upper() or None
+
+
+def main() -> int:
+    if not REGISTER.is_file():
+        print("no pending-upgrades register — nothing to guard")
+        return 0
+    rows = ROW_RE.findall(REGISTER.read_text(encoding="utf-8"))
+    pending = [num for num, status in rows if status.lower() == "pending"]
+    if not pending:
+        print("pending-upgrade guard: no pending rows")
+        return 0
+    if shutil.which("gh") is None:
+        print("pending-upgrade guard SKIPPED — gh unavailable; CI is authoritative")
+        return 0
+
+    violations: list[str] = []
+    for num in pending:
+        state = gh_issue_state(num)
+        if state is None:
+            print(
+                f"  #{num}: state UNKNOWN (gh could not resolve) — not failing on this"
+            )
+            continue
+        if state == "CLOSED":
+            violations.append(
+                f"#{num} is CLOSED but its register row is still `status: pending` — "
+                f"apply the owed upgrade and mark the row `resolved`"
+            )
+        else:
+            print(f"  #{num}: OPEN — pending row correctly held")
+
+    if violations:
+        print("PENDING-UPGRADE VIOLATIONS:")
+        for v in violations:
+            print(f"  - {v}")
+        return 1
+    print("pending-upgrade guard: all pending rows have OPEN unblocking issues")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The mechanical path for **"AC met-pending-#NNN"** rulings (#522's AC6 exp/log, ruled met-pending-#525). Makes the deferred upgrade un-skippable.

| Piece | What |
|---|---|
| `docs/foundations/pending-upgrades.md` | register — one row per conditionally-complete item → unblocking issue + `status: pending\|resolved` |
| `scripts/check_pending_upgrades.py` | CI guard — RED when a pending row's unblocking issue is CLOSED; skips gracefully if `gh` unavailable |
| `lean-foundations.yml` | runs the guard with `GH_TOKEN` + trigger paths |

The moment #525 merges, this goes red until AC6 is flipped pending→full and the row marked `resolved` — promise-to-update becomes a merge-gate (PATTERN-01: only an un-mergeable state holds). First entry: #474 AC6 → #525.

## Theory-element headline
N/A — CI tooling; no physical claim.

## CTH anchor impact
- **New anchors:** none.
- **Routing axis**:
  - [x] N/A — process tooling, no anchor-bearing paths

## Mechanical verification evidence
- [x] guard exits 0 now (#525 OPEN); would exit 1 on a closed unblocking issue
- [x] YAML valid; black/mypy clean
- [x] CI green — all checks pass + mergeable; Red Team + Gemini both APPROVE (probe-5 blocker confirmed resolved) @ 2026-06-08

Refs #507, #474/#522/#525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
