### PR TITLE
[infra] kill the aggregator-conflict class: union-merge + duplicate-import guard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,12 @@
 results/**/*.csv filter=lfs diff=lfs merge=lfs -text
 *.db filter=lfs diff=lfs merge=lfs -text
 *.hgdb filter=lfs diff=lfs merge=lfs -text
+
+# Foundations aggregator is an order-independent, append-only import list — every
+# foundation PR adds a line, so naive merge conflicts every sibling on it (bit us
+# 3×: #520, #522/#524, #524-again). Union merge concatenates both sides' additions
+# instead of conflicting. Lean imports are order-independent, so union is safe; a
+# rare duplicate-line (both sides add the same import) is caught by `lake build`
+# and check_layer_imports.py. CI is the backstop; the merge stops being a serial
+# conflict point.
+proofs/QBP/Foundations.lean merge=union

--- a/scripts/check_layer_imports.py
+++ b/scripts/check_layer_imports.py
@@ -64,7 +64,20 @@ def main() -> int:
     aggregator = PROOFS / "QBP" / "Foundations.lean"
     if aggregator.is_file():
         text = aggregator.read_text(encoding="utf-8")
-        imported = set(IMPORT_RE.findall(text))
+        all_imports = IMPORT_RE.findall(text)
+        # Duplicate-import guard: the aggregator uses git merge=union (append-only,
+        # order-independent), whose one failure mode is a duplicated import line
+        # when two branches add the same module. `lake build` tolerates duplicate
+        # imports, so this is the only place that catch can live.
+        seen: set[str] = set()
+        for imp in all_imports:
+            if imp in seen:
+                errors.append(
+                    f"QBP/Foundations.lean: duplicate import {imp} "
+                    f"(union-merge artifact — dedupe the aggregator)"
+                )
+            seen.add(imp)
+        imported = set(all_imports)
         quarantined = set(QUARANTINE_RE.findall(text))
         for lean in sorted((PROOFS / FOUNDATIONS_DIR).rglob("*.lean")):
             mod = module_of(lean)


### PR DESCRIPTION
## Summary

Root-cause fix for the recurring `proofs/QBP/Foundations.lean` merge conflict — it bit the foundation wave **three times** (#520; #522/#524 after #521; #524 again after #522/#523). Every foundation PR appends one import line to the single aggregator, so merging any sibling conflicts all the others. I've been resolving these reactively at merge-time; this removes the cause.

| Change | Effect |
|---|---|
| `.gitattributes`: `proofs/QBP/Foundations.lean merge=union` | git concatenates both sides' appended imports instead of conflicting (Lean imports are order-independent, so union is semantically safe) |
| `check_layer_imports.py`: duplicate-import guard | union-merge's sole failure mode is a doubled import line if two branches add the same module — and `lake build` *tolerates* duplicate imports, so this is the only place the catch can live. Now caught mechanically. |

After this, parallel foundation PRs stop being a serial conflict point — they merge in any order without manual resolution. Pairs with #507 §6 (mergeable-as-verdict-condition): that catches a conflict if one ever recurs; this prevents the dominant cause.

## Theory-element headline
N/A — repo merge infrastructure; no physical claim.

## CTH anchor impact
- **New anchors:** none.
- **Routing axis**:
  - [x] N/A — merge tooling, no anchor-bearing paths

## Mechanical verification evidence
- [x] layer linter clean on current tree; duplicate-detection logic unit-tested (doubled import → flagged)
- [x] union-merge semantics: Lean import order-independence makes concatenation safe
- [x] CI green — all checks pass + mergeable; Red Team + Gemini both APPROVE (converged) @ 2026-06-08

Refs #507 (gate family), #520/#522/#524 (the incidents this ends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
