### PR TITLE
[infra] link-check: PRs scan only changed .md; weekly cron full-sweep (closes #530)

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,5 +1,15 @@
 # .github/workflows/link-checker.yml
-# This workflow checks all markdown files for broken links.
+# Link checking, scoped to avoid flaky-external-link noise blocking unrelated PRs.
+#
+# Recurring incident (3x: #515 webaim, #529/#532 github.com): a PR scanning ALL
+# repo .md files fails on a transient timeout (Status 0 / ESOCKETTIMEDOUT) of an
+# external link in a file the PR never touched. A YAML-only or Lean-only PR has
+# no business being blocked by link-rot elsewhere.
+#
+# Fix (issue #530): on PRs, check ONLY the .md files the PR changed
+# (check-modified-files-only). A weekly scheduled full-repo scan catches rot in
+# untouched files, so nothing is lost — link-rot is surfaced on a cadence, not
+# imposed as a flaky tax on every unrelated PR.
 name: "Link Checker"
 
 on:
@@ -9,6 +19,9 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    # weekly full-repo sweep (Mondays 06:00 UTC) — catches rot in untouched files
+    - cron: '0 6 * * 1'
 
 jobs:
   markdown-link-check:
@@ -23,3 +36,7 @@ jobs:
           use-quiet-mode: 'yes'
           use-verbose-mode: 'yes'
           config-file: 'mlc_config.json'
+          # PRs: only the files they changed (kills unrelated-flake blocking).
+          # push-to-master / scheduled: full repo (modified-only is a no-op there,
+          # so the cron sweep still scans everything).
+          check-modified-files-only: ${{ github.event_name == 'pull_request' && 'yes' || 'no' }}


### PR DESCRIPTION
## Summary

Closes #530 — the recurring link-check flake (now **3×**: #515 webaim, #529/#532 github.com) that's currently **blocking the #531 Artin milestone**.

**Root cause:** the workflow scans *all* repo `.md` on every PR, so any PR is hostage to a transient external-link timeout (Status 0 / ESOCKETTIMEDOUT) in a file it never touched. #532 changes *zero* `.md` files yet fails on github.com timeouts in unrelated docs.

**Fix:** `check-modified-files-only` = `yes` on `pull_request` events → a PR only checks links in the `.md` it changed. A **weekly cron full-repo sweep** (Mondays 06:00 UTC) + the push-to-master full scan still surface link-rot in untouched files — just on a cadence, not as a flaky per-PR tax. (modified-only is a no-op on push/schedule, so those stay full-scan.)

Effect: YAML/Lean-only PRs (#532, #531, and most foundation PRs) get a trivially-passing link-check; genuine dead links in changed docs are still caught immediately; repo-wide rot is caught weekly.

## Theory-element headline
N/A — CI infra; no physical claim.

## CTH anchor impact
- **New anchors:** none.
- **Routing axis**:
  - [x] N/A — CI workflow only

## Mechanical verification evidence
- [x] YAML valid
- [x] this PR changes 0 `.md` → its own modified-only link-check passes trivially (self-proving)
- [x] CI green — all checks pass + mergeable; both APPROVE; modified-only link-check self-validated (0 .md changed) @ 2026-06-08

Closes #530. Unblocks #531 (Artin/AC2) + #532 once they refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
