### PR TITLE
[infra] #507 §8a notifier self-ticks the CI-green evidence box (FAULT-S4-002)

### DIFF
--- a/.github/workflows/pr-check-status.yml
+++ b/.github/workflows/pr-check-status.yml
@@ -194,10 +194,46 @@ jobs:
           add_label()    { gh pr edit "$PR" --repo "$REPO" --add-label    review-ready 2>/dev/null || true; }
           remove_label() { gh pr edit "$PR" --repo "$REPO" --remove-label review-ready 2>/dev/null || true; }
 
+          # ── CI-green evidence-box self-tick (#507 §8a, FAULT-S4-002 fix) ──
+          # The notifier owns the "CI green" EVIDENCE box on the PR body: tick at
+          # ALL-GREEN, un-tick at RED. This removes the orchestrator/watcher
+          # dependency that failed on #533 (a green CI whose box never got ticked
+          # because the watcher tail short-circuited). Deterministic, idempotent.
+          #
+          # GUARDRAIL (bma#245 / box-keeper spec): touches ONLY a checkbox line
+          # whose text contains "CI green"; the exclusion regex hard-blocks any
+          # review / sign-off / Human-Visual-Review box. Evidence boxes only —
+          # never a judgment box. Ticks at most ONE box (the first match).
+          set_ci_box() {  # $1 = mark: "x" (tick) or " " (untick)
+            local mark="$1" body newbody tmp
+            body=$(gh pr view "$PR" --repo "$REPO" --json body --jq .body) || return 0
+            newbody=$(printf '%s' "$body" | awk -v m="$mark" '
+              BEGIN { done = 0 }
+              {
+                line = $0
+                if (!done \
+                    && line ~ /^[[:space:]]*-[[:space:]]\[[ xX]\]/ \
+                    && tolower(line) ~ /ci green/ \
+                    && tolower(line) !~ /review|sign.?off|visual|hvr|red team|gemini|approve/) {
+                  sub(/\[[ xX]\]/, "[" m "]", line)
+                  done = 1
+                }
+                print line
+              }')
+            if [ "$newbody" != "$body" ]; then
+              tmp=$(mktemp)
+              printf '%s' "$newbody" > "$tmp"
+              gh pr edit "$PR" --repo "$REPO" --body-file "$tmp" 2>/dev/null \
+                && echo "CI-green evidence box set to [$mark]" || true
+              rm -f "$tmp"
+            fi
+          }
+
           # bodies via printf (YAML indentation inside literals renders as code blocks)
           if [ "$NTECHFAIL" -gt 0 ]; then
-            # ── RED: revoke review-ready ──
+            # ── RED: revoke review-ready + withdraw CI-green evidence box ──
             remove_label
+            set_ci_box " "
             LIST=$(echo "$TECH_FAILED" | jq -r '.[] | "- ❌ [\(.name)](\(.html_url)) — \(.conclusion)"')
             BODY=$(printf '%s\n## ❌ Checks FAILED — %s of %s @ %s\n\nHead: `%s`\n\n%s\n\n`review-ready` revoked: not reviewable until tech-green again. Machine-posted; updates per head SHA.' \
               "$MARKER" "$NTECHFAIL" "$TOTAL" "$TS" "$SHA" "$LIST")
@@ -207,7 +243,11 @@ jobs:
             BODY=$(printf '%s\n## 🟢 Tech-green — review-ready @ %s\n\nHead: `%s`. All non-review checks pass; review-completeness gates await artifacts.\n\n**Review checklist (sequential; each post must include `<!-- reviewed-sha: %s -->`):**\n- [ ] Red Team review (Sabine/Grothendieck/Knuth)\n- [ ] Gemini review (Furey/Feynman, real API)\n- [ ] Synthesis + fix rounds as needed (each fix push re-runs this cycle)\n- [ ] Human Visual Review (beekeeper)\n\nMachine-posted; updates per head SHA.' \
               "$MARKER" "$TS" "$SHA" "$SHA")
           else
-            # ── ALL-GREEN: review-freshness check (patch-id via marker) ──
+            # ── ALL-GREEN: tick the CI-green evidence box, then review-freshness ──
+            # Every check (incl. review gates) passed → the "CI green" evidence
+            # box is now machine-true. Review FRESHNESS is reported separately
+            # below; it does not gate this box (CI-green ≠ reviews-fresh).
+            set_ci_box "x"
             LASTREV=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" --paginate \
                       --jq '[.[] | .body]' | jq -s 'add // []' \
                       | jq -r '[.[] | capture("<!-- reviewed-sha: (?<s>[0-9a-f]{7,40}) -->").s] | last // empty')


### PR DESCRIPTION
## Summary

The PR check-status notifier now **owns the "CI green" evidence box** on the PR
body: it ticks the box at **ALL-GREEN** and withdraws it at **RED**. This closes
**FAULT-S4-002** — the failure mode where a green CI never got its evidence box
ticked because the orchestrator's watcher tail short-circuited (observed on #533).
The tick is now mechanical and deterministic, not memory-dependent.

This is **#507 §8a** (the notifier self-tick half of the post-milestone box-state
work). The companion artifact is the box-keeper subrole spec
(`docs/workflows/herschel_box_keeper.md`).

## Mechanism

A `set_ci_box` shell helper, called in two branches of the existing verdict logic:

| Notifier verdict | Action |
|---|---|
| ALL-GREEN (every check incl. review gates passes) | `set_ci_box "x"` — tick |
| RED (a tech check failed) | `set_ci_box " "` — withdraw |
| TECH-GREEN (reviews owed) | untouched — CI not fully green yet |

CI-green and review-freshness are **separate axes**: the box reflects *CI is green*;
freshness is still reported in the verdict body and does not gate the box.

## Guardrail (bma#245 / box-keeper spec)

`set_ci_box` touches **only** a checkbox line whose text contains `"CI green"`, and
an exclusion regex (`review|sign-off|visual|hvr|red team|gemini|approve`)
hard-blocks every judgment box. **Evidence boxes only — never a sign-off or
Human-Visual-Review box.** Ticks at most one box; idempotent; safe no-op when no
such box exists.

## Validation

Logic tested standalone against: fresh-tick, untick-on-RED, idempotent re-tick,
no-CI-green-box (no false edit), and a guardrail-breach attempt (a review line
with "CI green" wording → correctly skipped). YAML parses. All pass.

## Test plan
- [x] CI green ← notifier verdict canonical
- [x] Red Team review (Sabine / Grothendieck / Knuth)
- [x] Gemini review (Furey / Feynman, real API)
- [x] Human Visual Review (beekeeper) — beekeeper directed merge 2026-06-11

## Acceptance criteria (from #507 §8a)
- [x] notifier self-ticks the CI-green box at ALL-GREEN
- [x] withdraws it at RED
- [x] guardrail: never ticks sign-off / HVR boxes
- [x] idempotent + safe no-op when box absent

Self-demonstrating: once merged, this notifier will tick the CI-green box on its
own future PRs.

Refs #507. FAULT-S4-002.

