### PR TITLE
[theory] #564 keystone opened: SSB-possible, but the scale-free-R shortcut is BLOCKED (no shortcut)

### DIFF
--- a/analysis/564-vconstants-keystone/README.md
+++ b/analysis/564-vconstants-keystone/README.md
@@ -21,28 +21,34 @@ Built from the #559-verified ingredients: V(y) = a|y|² + b·Re⟨X(y e₄),(y e
 ## B. v → constants — the genuine open frontier
 How does each dimensionless residue depend on v? This is **QBP-specific and not the SM**: in the SM, α is *not* a function of the Higgs VEV (it's a gauge coupling). QBP must supply its own mechanism by which α (the U(1)/EM sector), μ = m_p/m_e, and Λ_QCD/m_q arise from / couple to the crystallisation (2,2). **This is the hard, unsolved part** (AC-B1/B2). No claim made here.
 
-## C. R_αμ reduces to a RATIO OF EXPONENTS (scale-independent) — the tractability win
-R_αμ is a ratio of logarithmic derivatives. If each constant couples to the VEV as a **power law** f(v) = f₀·v^p, then d ln f/d ln v = p (constant — independent of v and of all potential coefficients), so
+## C. The "scale-independent R" shortcut — ❌ BLOCKED (illusory)
 
-$$R_{\alpha\mu} = \frac{d\ln\alpha/d\ln v}{d\ln\mu/d\ln v} = \frac{p_\alpha}{p_\mu}\quad(\text{a pure ratio of exponents, scale-free}).$$
+The attempted shortcut: if each constant couples to the VEV as a **power law** f(v)=f₀·v^p, then R_αμ = p_α/p_μ — a ratio of exponents, independent of the absolute scale and the potential coefficients. **The adversarial gate (Gemini Furey/Feynman) BLOCKED this, correctly:**
 
-**Consequence:** the falsifiable number is **independent of the absolute VEV scale AND of the (undetermined) potential coefficients** — it reduces to the **coupling exponents** (p_α, p_μ, p_QCD). So "derive R" no longer requires solving the hard absolute-scale problem (A's crux); it requires only Sub-problem B's *exponents*. This drops the hardest piece — *provided* the couplings are power laws (flagged assumption — logarithmic/running couplings would make R scale-dependent).
+1. **The power-law premise is broken for α.** α is a **gauge coupling** — in QFT it runs **logarithmically** (α⁻¹ ~ ln(v/Λ)), *not* as a power law. Substituting a log dependence makes R_αμ **scale-dependent** after all. Scale-independence holds only if *both* couplings are power-law; α almost certainly isn't. The "win" is dead on arrival for the gauge channel.
+2. **Relocation, not progress.** The unknown functional dependence was merely bundled into "constants" p_α, p_μ. Computing them *is* the full crystallisation→constants mechanism (Sub-problem B) — all the intractable complexity, just renamed.
+3. **The math is trivial** (power law ⇒ constant log-derivative); celebrating it as a structural win is a distraction from the broken premise.
 
-## Net (honest)
-- **A:** the algebra gives a concrete SSB Mexican hat (negative mass² from non-commutativity, triggered by an imaginary background). ✅ mechanism shown; absolute scale open.
-- **C:** R_αμ = p_α/p_μ, scale- and coefficient-independent under power-law coupling. ✅ the falsifiable number is reduced to exponents.
-- **B:** deriving the exponents p_α, p_μ, p_QCD (QBP's mechanism for how the constants couple to the (2,2)) is the **genuine remaining frontier** — untouched, hard, QBP-specific.
+**Verdict: the C-reduction is illusory.** It does NOT drop the hardest piece. (The earlier "tractability win" framing is retracted.)
 
-> **The keystone is now sharply localised:** not "solve the dynamics + the scale + the map" but **"derive the three coupling exponents."** That is the single thing standing between QBP and a parameter-free, falsifiable drift-ratio testable on the Th-229 clock network (#539).
+## A (revisited) — demoted: SSB is *possible*, the potential is *not* parameter-free
+The adversary also fairly hit Sub-problem A: choosing exactly the cross-coupling term that yields the convenient isotropic (|X_re|²−|X_im|²) mass matrix, and invoking an "imaginary background" to force the negative mass², is **model-building, not a parameter-free consequence** of the algebra. Honest demotion: §A demonstrates that the octonion non-commutativity **can** source a Mexican hat (existence — SSB is not forbidden, strengthening #559), but it is **not** "the canonical crystallisation potential." The specific term + background are inputs.
+
+## Net (honest) — the keystone is opened and its real difficulty mapped; no shortcut exists
+- **A:** SSB is *possible* (the algebra contains a negative cross-coupling) — existence only; the specific potential is model-building, scale open.
+- **C:** the scale-independent-R shortcut is **BLOCKED** (α runs logarithmically; R is not generically scale-free).
+- **B:** the full crystallisation→constants mechanism is the **irreducible frontier** — no shortcut bypasses it.
+
+> **The sharpened crux (the adversary's mandate):** the real prior question is *does QBP's crystallisation give α a power-law or a logarithmic dependence on the VEV?* — i.e. does QBP **reproduce standard QFT gauge-coupling running, or replace it?** Until that is answered, neither R nor the spectrum is derivable. This is the genuine, deep next question — and it is bigger than #564 alone.
 
 ## AC status (#564)
 | AC | Status |
 |----|--------|
-| A1 (build V, show Mexican hat) | ✅ done — explicit, algebra-sourced negative mass² |
+| A1 (build V, show Mexican hat) | 🟡 existence shown (SSB *possible*); demoted — specific potential is model-building, not parameter-free |
 | A2 (canonical coefficients / parameter-free v) | ⏳ open (the absolute-scale crux) |
-| B1/B2 (α, μ, Λ_QCD coupling to the VEV) | ⏳ **open frontier** — the real remaining work |
-| C1 (is R scale-independent?) | ✅ **yes, under power-law coupling** — R = ratio of exponents |
-| C2 (derive R) | ⏳ reduces to B (the exponents) |
+| B1/B2 (α, μ, Λ_QCD coupling to the VEV) | ⏳ **irreducible frontier** — no shortcut |
+| C1 (is R scale-independent?) | ❌ **NO** — fails for log-running gauge couplings (α). Shortcut blocked |
+| C2 (derive R) | ⏳ requires the full B mechanism; gated on the power-law-vs-log question |
 
 ## Provenance
-Continuation of #559 (the SSB ingredients) + #539 (the drift observable), per the #563 `CONJ-vconstants-keystone`. The imaginary-background SSB trigger and the R=ratio-of-exponents reduction are this pass's results. Recorded by @qbp-oppenheimer; the C-reduction adversarially tested before adoption (see PR thread).
+Continuation of #559 (the SSB ingredients) + #539 (the drift observable), per the #563 `CONJ-vconstants-keystone`. This pass: built the explicit Mexican-hat potential (existence of algebra-sourced SSB), attempted the scale-independent-R shortcut, and the adversarial gate (Gemini Furey/Feynman) **BLOCKED the shortcut** as illusory (α runs logarithmically, not power-law). The honest residue: the keystone has no shortcut; the real prior question is power-law-vs-log running of α under crystallisation. Recorded by @qbp-oppenheimer.

--- a/analysis/564-vconstants-keystone/README.md
+++ b/analysis/564-vconstants-keystone/README.md
@@ -1,0 +1,48 @@
+# #564 — The v→constants keystone (first pass)
+
+**Status:** WORKING — Sub-problem A built, Sub-problem C reduced, Sub-problem B is the open frontier · **Issue:** #564 (child of #559 + #539) · **Date:** 2026-06-14
+**Discipline:** build the rigorous object → adversarially test → predict a dimensionless number or it dies.
+
+---
+
+## The keystone
+Derive **α(v), μ(v), Λ_QCD(v)** — how the SM dimensionless residues depend on the crystallisation order-parameter magnitude v = |(2,2) VEV|. The falsifiable target is **R_αμ = (d ln α/dv)/(d ln μ/dv)**, the parameter-free number that is QBP's only genuine drift fingerprint (Gemini "derive or die", #539).
+
+## A. The crystallisation potential & VEV — the algebra supplies a Mexican hat (`potential_construction.py`)
+
+Built from the #559-verified ingredients: V(y) = a|y|² + b·Re⟨X(y e₄),(y e₄)X⟩ + c(|y|²)², where the middle term is the **non-commutative cross-coupling** (the algebra's sign-indefinite source) for a retained-sector background X.
+
+**Two concrete findings:**
+1. **The cross-coupling matrix is isotropic with sign (|X_real|² − |X_imag|²):** M(X) = (|X_re|² − |X_im|²)·I. So the **negative** mass term — the SSB trigger — appears precisely when the background is **dominantly imaginary**. In QBP's own formalism Im(ℍ)={i,j,k} are the *spatial* directions, so a **spatial/imaginary background drives the crystallisation**. (Structural fact; not over-read.)
+2. **V(y) is a genuine Mexican hat** when b·|X_im|² > a (the negative cross-coupling beats the positive norm mass): mass² = a − b|X_im|² < 0, minimum at v = √((b|X_im|² − a)/2c). Concretely realised (v = 2.24, 2.50 for sample coefficients). **#559's "ingredients available" is now an explicit symmetry-breaking potential**, with the negative mass² *supplied by the octonion non-commutativity* rather than put in by hand (unlike the SM, where the negative Higgs mass² is an unexplained input).
+
+**Open (AC-A2, the crux):** the absolute scale v depends on the coefficients (a, b, c, |X|). Whether a canonical action principle fixes them — giving a parameter-free v — is unresolved. *But Sub-problem C shows the falsifiable prediction may not need it.*
+
+## B. v → constants — the genuine open frontier
+How does each dimensionless residue depend on v? This is **QBP-specific and not the SM**: in the SM, α is *not* a function of the Higgs VEV (it's a gauge coupling). QBP must supply its own mechanism by which α (the U(1)/EM sector), μ = m_p/m_e, and Λ_QCD/m_q arise from / couple to the crystallisation (2,2). **This is the hard, unsolved part** (AC-B1/B2). No claim made here.
+
+## C. R_αμ reduces to a RATIO OF EXPONENTS (scale-independent) — the tractability win
+R_αμ is a ratio of logarithmic derivatives. If each constant couples to the VEV as a **power law** f(v) = f₀·v^p, then d ln f/d ln v = p (constant — independent of v and of all potential coefficients), so
+
+$$R_{\alpha\mu} = \frac{d\ln\alpha/d\ln v}{d\ln\mu/d\ln v} = \frac{p_\alpha}{p_\mu}\quad(\text{a pure ratio of exponents, scale-free}).$$
+
+**Consequence:** the falsifiable number is **independent of the absolute VEV scale AND of the (undetermined) potential coefficients** — it reduces to the **coupling exponents** (p_α, p_μ, p_QCD). So "derive R" no longer requires solving the hard absolute-scale problem (A's crux); it requires only Sub-problem B's *exponents*. This drops the hardest piece — *provided* the couplings are power laws (flagged assumption — logarithmic/running couplings would make R scale-dependent).
+
+## Net (honest)
+- **A:** the algebra gives a concrete SSB Mexican hat (negative mass² from non-commutativity, triggered by an imaginary background). ✅ mechanism shown; absolute scale open.
+- **C:** R_αμ = p_α/p_μ, scale- and coefficient-independent under power-law coupling. ✅ the falsifiable number is reduced to exponents.
+- **B:** deriving the exponents p_α, p_μ, p_QCD (QBP's mechanism for how the constants couple to the (2,2)) is the **genuine remaining frontier** — untouched, hard, QBP-specific.
+
+> **The keystone is now sharply localised:** not "solve the dynamics + the scale + the map" but **"derive the three coupling exponents."** That is the single thing standing between QBP and a parameter-free, falsifiable drift-ratio testable on the Th-229 clock network (#539).
+
+## AC status (#564)
+| AC | Status |
+|----|--------|
+| A1 (build V, show Mexican hat) | ✅ done — explicit, algebra-sourced negative mass² |
+| A2 (canonical coefficients / parameter-free v) | ⏳ open (the absolute-scale crux) |
+| B1/B2 (α, μ, Λ_QCD coupling to the VEV) | ⏳ **open frontier** — the real remaining work |
+| C1 (is R scale-independent?) | ✅ **yes, under power-law coupling** — R = ratio of exponents |
+| C2 (derive R) | ⏳ reduces to B (the exponents) |
+
+## Provenance
+Continuation of #559 (the SSB ingredients) + #539 (the drift observable), per the #563 `CONJ-vconstants-keystone`. The imaginary-background SSB trigger and the R=ratio-of-exponents reduction are this pass's results. Recorded by @qbp-oppenheimer; the C-reduction adversarially tested before adoption (see PR thread).

--- a/analysis/564-vconstants-keystone/potential_construction.py
+++ b/analysis/564-vconstants-keystone/potential_construction.py
@@ -1,0 +1,115 @@
+"""
+#564 Sub-problem A: build the crystallisation potential V(y) from the verified #559
+ingredients and characterise its minimum. Sub-problem C: is R_αμ scale-independent?
+
+V(y) = a|y|^2  +  b * Re<X(y e4),(y e4)X>  +  c (|y|^2)^2
+  - |y|^2: the Euclidean octonion norm (positive).
+  - Re<X(ye4),(ye4)X>: the #559 NON-COMMUTATIVE cross-coupling, NEGATIVE-definite for
+    imaginary background X (this is the algebra-supplied negative mass term).
+  - c(|y|^2)^4-term: the quartic that stabilises (lowest SO(4)-invariant quartic = (|y|^2)^2).
+"""
+
+import numpy as np, numpy.linalg as la
+
+rng = np.random.default_rng(3)
+
+
+def qmul(p, q):
+    w0, x0, y0, z0 = p
+    w1, x1, y1, z1 = q
+    return np.array(
+        [
+            w0 * w1 - x0 * x1 - y0 * y1 - z0 * z1,
+            w0 * x1 + x0 * w1 + y0 * z1 - z0 * y1,
+            w0 * y1 - x0 * z1 + y0 * w1 + z0 * x1,
+            w0 * z1 + x0 * y1 - y0 * x1 + z0 * w1,
+        ]
+    )
+
+
+def qconj(p):
+    return np.array([p[0], -p[1], -p[2], -p[3]])
+
+
+def omul(A, B):
+    p, q = A[:4], A[4:]
+    r, s = B[:4], B[4:]
+    return np.concatenate(
+        [qmul(p, r) - qmul(qconj(s), q), qmul(s, p) + qmul(q, qconj(r))]
+    )
+
+
+def emb(y4):
+    return np.concatenate([np.zeros(4), y4])
+
+
+def inner(a, b):
+    return float(a @ b)
+
+
+b4 = [np.eye(4)[k] for k in range(4)]
+
+
+def crossM(X):  # matrix of Re<X(ye4),(ye4)X> in y
+    M = np.zeros((4, 4))
+    for i in range(4):
+        for j in range(4):
+            f = lambda y: inner(
+                omul(np.concatenate([X, np.zeros(4)]), emb(y)),
+                omul(emb(y), np.concatenate([X, np.zeros(4)])),
+            )
+            M[i, j] = 0.25 * (f(b4[i] + b4[j]) - f(b4[i] - b4[j]))
+    return 0.5 * (M + M.T)
+
+
+print("=== M(X) signature for various backgrounds (the negative-mass source) ===")
+for name, X in [
+    ("X=e1 (imag unit)", np.array([0, 1.0, 0, 0])),
+    ("X=1 (real unit)", np.array([1.0, 0, 0, 0])),
+    ("X=(1+e1)/sqrt2 (mixed)", np.array([1, 1.0, 0, 0]) / np.sqrt(2)),
+    ("X=imag generic", np.concatenate([[0], rng.standard_normal(3)])),
+]:
+    M = crossM(X)
+    ev = np.round(la.eigvalsh(M), 4)
+    print(
+        f"  {name:26s} eig={ev}  (|X|^2={inner(X,X):.3f})  -> isotropic={np.allclose(ev,ev[0])}"
+    )
+
+# So for imaginary X: M = -|X|^2 I  (isotropic negative). Quadratic mass term coefficient:
+# V(y) = (a - b|X_im|^2)|y|^2 + c(|y|^2)^2  for imaginary background, |X_im|^2 = m.
+print("\n=== V(y) is a Mexican hat iff the negative cross-coupling dominates ===")
+
+
+def vev(a, b, m, c):
+    mass2 = a - b * m  # coefficient of |y|^2
+    if mass2 >= 0:
+        return 0.0, mass2
+    return np.sqrt((b * m - a) / (2 * c)), mass2  # |y|_min
+
+
+for a, b, m, c in [(1.0, 0.5, 1.0, 0.1), (1.0, 2.0, 1.0, 0.1), (0.5, 1.0, 3.0, 0.2)]:
+    v, mass2 = vev(a, b, m, c)
+    print(
+        f"  a={a},b={b},|X|^2={m},c={c}: mass^2={mass2:+.3f} -> {'MEXICAN HAT, v=%.4f'%v if v>0 else 'no SSB (v=0)'}"
+    )
+
+# === Sub-problem C: is R_alpha,mu scale-independent? ===
+# If a constant couples to the VEV as a POWER LAW  f(v) = f0 * v^p, then
+#   dln f/dln v = p  (CONSTANT, independent of v and of all potential coefficients).
+#   R_ab = (dln A/dv)/(dln B/dv) = p_A / p_B   -> a pure RATIO OF EXPONENTS, scale-free.
+print("\n=== Sub-problem C: R_ab structure ===")
+print("If alpha(v)=a0*v^p_alpha and mu(v)=m0*v^p_mu (power-law coupling to the VEV),")
+print("then R_alpha,mu = (dln alpha/dln v)/(dln mu/dln v) = p_alpha/p_mu :")
+for pa, pmu in [(1, -1), (2, -1), (1, 1), (-1, 2)]:
+    print(
+        f"   p_alpha={pa:+d}, p_mu={pmu:+d}  ->  R = {pa/pmu:+.4f}   (scale-INDEPENDENT)"
+    )
+print(
+    "\n=> R is independent of the absolute VEV v AND of the potential coefficients (a,b,c,|X|)"
+)
+print(
+    "   IFF the couplings are power laws. The falsifiable number reduces to the EXPONENTS,"
+)
+print(
+    "   i.e. to Sub-problem B (how each constant couples to the (2,2)) -- NOT the hard scale."
+)

--- a/analysis/564-vconstants-keystone/potential_construction_output.txt
+++ b/analysis/564-vconstants-keystone/potential_construction_output.txt
@@ -1,0 +1,22 @@
+=== M(X) signature for various backgrounds (the negative-mass source) ===
+  X=e1 (imag unit)           eig=[-1. -1. -1. -1.]  (|X|^2=1.000)  -> isotropic=True
+  X=1 (real unit)            eig=[1. 1. 1. 1.]  (|X|^2=1.000)  -> isotropic=True
+  X=(1+e1)/sqrt2 (mixed)     eig=[0. 0. 0. 0.]  (|X|^2=1.000)  -> isotropic=True
+  X=imag generic             eig=[-10.8716 -10.8716 -10.8716 -10.8716]  (|X|^2=10.872)  -> isotropic=True
+
+=== V(y) is a Mexican hat iff the negative cross-coupling dominates ===
+  a=1.0,b=0.5,|X|^2=1.0,c=0.1: mass^2=+0.500 -> no SSB (v=0)
+  a=1.0,b=2.0,|X|^2=1.0,c=0.1: mass^2=-1.000 -> MEXICAN HAT, v=2.2361
+  a=0.5,b=1.0,|X|^2=3.0,c=0.2: mass^2=-2.500 -> MEXICAN HAT, v=2.5000
+
+=== Sub-problem C: R_ab structure ===
+If alpha(v)=a0*v^p_alpha and mu(v)=m0*v^p_mu (power-law coupling to the VEV),
+then R_alpha,mu = (dln alpha/dln v)/(dln mu/dln v) = p_alpha/p_mu :
+   p_alpha=+1, p_mu=-1  ->  R = -1.0000   (scale-INDEPENDENT)
+   p_alpha=+2, p_mu=-1  ->  R = -2.0000   (scale-INDEPENDENT)
+   p_alpha=+1, p_mu=+1  ->  R = +1.0000   (scale-INDEPENDENT)
+   p_alpha=-1, p_mu=+2  ->  R = -0.5000   (scale-INDEPENDENT)
+
+=> R is independent of the absolute VEV v AND of the potential coefficients (a,b,c,|X|)
+   IFF the couplings are power laws. The falsifiable number reduces to the EXPONENTS,
+   i.e. to Sub-problem B (how each constant couples to the (2,2)) -- NOT the hard scale.


### PR DESCRIPTION
## Summary

Banks the honest result of **opening the v→constants keystone (#564)**: the first crack found **no shortcut**, and the adversarial gate **BLOCKED** the one tractable-looking path. This PR records that negative cleanly (we won't re-walk it) and sharpens the real open question.

## What happened
| Sub-problem | Outcome |
|---|---|
| **A** — crystallisation potential | 🟡 **SSB is possible** — the #559 negative cross-coupling forms an explicit Mexican hat (M(X)=(\|X_re\|²−\|X_im\|²)·I; imaginary background → negative mass²). **Demoted** by the adversary: the specific term+background are model-building, not parameter-free. Existence, not *the* potential. |
| **C** — "scale-free R" shortcut | ❌ **BLOCKED** — α is a gauge coupling, runs **logarithmically** not power-law, so R_αμ is *not* scale-independent. Relocation, not progress. The "tractability win" is retracted. |
| **B** — v→constants mechanism | ⏳ **irreducible frontier** — no shortcut bypasses it |

## The sharpened crux
> Does QBP's crystallisation **reproduce standard QFT gauge-coupling running, or replace it?** Until answered, neither R_αμ nor the spectrum is derivable. This is bigger than #564 — it's about QBP's relationship to QFT.

## Files
- `potential_construction.py` (+ output) — the Mexican-hat construction + the (now-blocked) R-reduction computation.
- `README.md` — the full honest record, including the §C BLOCK and the §A demotion.

## CTH anchor impact
- [ ] theory-axis  ·  [ ] schema-axis  ·  [ ] two-axis  ·  [x] not-conflict — analysis artifact (`analysis/`), no canonical-ledger mutation. Any anchor (the no-shortcut finding) lands in a later batch.  ·  [ ] N/A

## Test plan
- [x] `potential_construction.py` runs; M(X) signature + Mexican-hat + R-structure reproduced
- [x] The shortcut was adversarially tested and **BLOCKED**; the doc records the BLOCK rather than the overclaim (no "win" survives)
- [x] §A honestly demoted to existence; §B marked irreducible

Refs #564, #559, #539, #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)
