### PR TITLE
[cth] +5 anchors: #570-#573 findings — CTH-currency V&V remediation

### DIFF
--- a/analysis/566-loop-closure-machine/README.md
+++ b/analysis/566-loop-closure-machine/README.md
@@ -1,0 +1,52 @@
+# The loop-closure machine — first build (option 1, the "generator" long shot)
+
+**Status:** FIRST BUILD — framework + N_free counted; the machine bottlenecks on ONE isolated construction · **For:** #566 (triangle bootstrap), #570 (the generator question) · **Date:** 2026-06-18
+**Goal:** determine whether triangle loop-closure **over-determines** the free dynamical data (→ predicts the constant values = "generator") or not (→ "organization"). Per #566 §3a this needs: a computable truncation, a sealed parameter space, the closure identity, then sign(N_constraint − N_free).
+**Discipline:** the #570 gate applied to this construction; do **not** invent the holographic edge to force a result.
+
+---
+
+## 1. The minimal truncation (sealed parameter space)
+
+The smallest instance where all three corners are non-trivial: the **ℍ→𝕆 crystallisation** (the 8-dim octonion; the (2,2) complement of #559/#571). The parameter space is **sealed by axiom** to: the octonion multiplication (fixed by Cayley-Dickson — *no* free data), the Euclidean norm form (the metric source, #474 D10), and the crystallisation potential on the (2,2). No other free data is admitted (sealing = the falsifiability prerequisite, #566 §3a-2).
+
+## 2. The three edges, concretely
+
+| Edge | Map | Free data → N_free | Closing constraint → N_constraint |
+|---|---|---|---|
+| **Substrate → Foundation** (hosting) | hypergraph reproduces the octonion product | ~0 (the product is CD-fixed; the hypergraph is determined up to iso by "host the table") | the hosting condition — constrains the *substrate*, not the dynamics |
+| **Foundation → Physics** (bilinear → geometry + dynamics) | norm form → metric (**rigid**, Euclidean); potential V(y) → dynamics | **the dynamical content** — see §3 | the projected geometry must satisfy the associator-dictated field eqns |
+| **Physics → Substrate** (holographic lock, RT) | areas ⇒ substrate entanglement (S = Area/4G) | the holographic boundary data | **RT: entropy(partition) = area, per partition** — *the source of over-determination, if any* |
+
+**Closure** = the round trip Foundation→Physics→Substrate→Foundation returns the same algebra (the bootstrap consistency / fixed-point condition).
+
+## 3. N_free — counted (tractable)
+
+The only genuinely free dynamical data is the crystallisation potential (#564/#571):
+$$V(y) = a\,|y|^2 + b\,\mathrm{Re}\langle Xy, yX\rangle + c\,(|y|^2)^2 ,\qquad \text{background magnitude } |X|.$$
+- Raw coefficients: a, b, c, |X| (4). Remove the overall scale (units, unphysical) → the **dimensionless dynamical content is ≈ 2** (e.g. the Mexican-hat mass² ratio m²/scale with m² = a − b|X|², and the quartic depth) — these are what fix the VEV v and hence (via the v→constants map) the values.
+
+**N_free ≈ 2 dimensionless.** Small — exactly as the bootstrap needs (few free params for closure to over-determine).
+
+## 4. The gate: edge 3 (holographic RT) — non-constructive, and it is the whole ballgame
+
+For the bootstrap to over-determine, N_constraint must exceed N_free (≈2). The constraints can only come from **edge 3** (RT: area = entropy per partition) — edges 1 (hosting) and 2 (rigid metric) constrain the *substrate/geometry*, not the potential coefficients. At a finite truncation the octonion structure has *many* partitions → RT would give *many* area=entropy conditions → **plausibly over-determining (N_constraint ≫ N_free).** So in principle the bootstrap could close decisively.
+
+**But edge 3 is not constructive** (confirmed: QBP has no RT map — only the #566 §5 statement that one is *needed*; the substrate work #554/#556 is the cohesive/type-theory layer, not an RT map). Two blockers, in dependency order:
+1. **The substrate must be concrete first** (#554/#556, open) — to define "partitions" and their "entanglement entropy" at all.
+2. **The RT map must be constructed** (state → partition → area, with an argument that RT *holds* in the QBP substrate rather than being borrowed from AdS/CFT — #566 §5).
+
+Until both exist, **N_constraint cannot be counted, the closure fixed-point cannot be written, and sign(N_constraint − N_free) cannot be evaluated.** The bootstrap *cannot be posed.*
+
+## 5. The deeper structural point (why edge 3 is unavoidable, not a dodge)
+
+The loop is three **kinematic** maps (algebra structure → geometry → entanglement → algebra). The **values** live in the **dynamical** sector (the potential coefficients → VEV). A consistency condition on the kinematic loop reaches the dynamical coefficients **only if** the geometry depends on the VEV (so the dynamics feeds the loop). In QBP it does — the geometry transitions 𝕆→ℍ as crystallisation proceeds — **but that coupling routes entirely through edge 3** (the VEV changes the areas, which via RT change the substrate, which must host the algebra). So edge 3 is not one edge among three; it is **the only channel through which loop-closure can touch the values.** No edge 3 ⇒ the loop is value-blind. This is a structural result, not an excuse.
+
+## 6. Verdict — the machine is ~⅔ built; the generator question reduces to ONE construction
+
+> **The loop-closure machine's counting framework is built and N_free ≈ 2 is in hand. The entire "generator vs organization" question now reduces to a single, precisely-isolated construction: a constructive holographic (RT) edge — entropy(partition) = area — in a concretized QBP substrate.** With it, N_constraint is countable (plausibly ≫ N_free → over-determined → predict-or-falsify). Without it, the bootstrap cannot be posed, so it cannot over-determine the values, and **"organization, not generator" stands** — *but the open question is now one well-defined object, not a vague program.*
+
+The dependency chain to finish the machine: **concrete substrate (#554/#556) → RT map (edge 3) → count N_constraint → sign(N_c − N_f).** This is the honest state: option 1's last path is not closed, but it is reduced to building the holographic edge — and that edge was independently flagged (#566 §5) as the triangle's make-or-break.
+
+## 7. Provenance
+Option 1, the loop-closure "generator" long shot (#566/#570), 2026-06-18. The DOF framework, the N_free≈2 count, and the structural result that edge 3 is the sole value-channel are this build's results; the holographic edge's non-existence is confirmed against QBP's current substrate work. `loop_closure_dof.py`. Recorded by @qbp-oppenheimer; adversarially tested before adoption (see PR thread).

--- a/analysis/566-loop-closure-machine/README.md
+++ b/analysis/566-loop-closure-machine/README.md
@@ -20,33 +20,36 @@ The smallest instance where all three corners are non-trivial: the **ℍ→𝕆 
 
 **Closure** = the round trip Foundation→Physics→Substrate→Foundation returns the same algebra (the bootstrap consistency / fixed-point condition).
 
-## 3. N_free — counted (tractable)
+## 3. N_free — NOT ≈ 2 (corrected: a massive undercount)
 
-The only genuinely free dynamical data is the crystallisation potential (#564/#571):
-$$V(y) = a\,|y|^2 + b\,\mathrm{Re}\langle Xy, yX\rangle + c\,(|y|^2)^2 ,\qquad \text{background magnitude } |X|.$$
-- Raw coefficients: a, b, c, |X| (4). Remove the overall scale (units, unphysical) → the **dimensionless dynamical content is ≈ 2** (e.g. the Mexican-hat mass² ratio m²/scale with m² = a − b|X|², and the quartic depth) — these are what fix the VEV v and hence (via the v→constants map) the values.
+My first draft counted only the continuous coefficients of *one* potential I chose to write down. That is a severe undercount (adversarial pass). N_free actually includes:
+- the **continuous** potential coefficients (a, b, c, |X| in V(y)=a|y|²+b·Re⟨Xy,yX⟩+c(|y|²)² → ~2 dimensionless), **plus**
+- the **functional/discrete** DOF — *why a quartic? why those contractions?* The *form* of V is itself unconstrained, **plus**
+- the **substrate configurational DOF** — unless edges 1+2 *provably freeze* the hypergraph (they do **not**, because the substrate is non-concrete, #554/#556), the substrate harbours a **large, unconstrained** number of configurational degrees of freedom.
 
-**N_free ≈ 2 dimensionless.** Small — exactly as the bootstrap needs (few free params for closure to over-determine).
+**So N_free is large and uncounted, not ≈ 2.** This *weakens*, not strengthens, the case for over-determination — there is no warrant for "few free params."
 
 ## 4. The gate: edge 3 (holographic RT) — non-constructive, and it is the whole ballgame
 
-For the bootstrap to over-determine, N_constraint must exceed N_free (≈2). The constraints can only come from **edge 3** (RT: area = entropy per partition) — edges 1 (hosting) and 2 (rigid metric) constrain the *substrate/geometry*, not the potential coefficients. At a finite truncation the octonion structure has *many* partitions → RT would give *many* area=entropy conditions → **plausibly over-determining (N_constraint ≫ N_free).** So in principle the bootstrap could close decisively.
+The constraints could only come from **edge 3** (RT: area = entropy per partition) — edges 1 (hosting) and 2 (rigid metric) constrain the *substrate/geometry*, not the potential coefficients. My first draft claimed "many partitions → N_constraint ≫ N_free → over-determined." **That is hand-waving and is retracted:** many partitions ≠ many *independent* constraints. The algebra's symmetries will very likely make the RT conditions **highly degenerate** — a million equations collapsing to "x = y" (rank ≪ count), or to "1 = 0" (no solution). **Over-determination is a claim about the constraint-matrix RANK, which is uncomputable here** — and the count alone says nothing.
 
-**But edge 3 is not constructive** (confirmed: QBP has no RT map — only the #566 §5 statement that one is *needed*; the substrate work #554/#556 is the cohesive/type-theory layer, not an RT map). Two blockers, in dependency order:
-1. **The substrate must be concrete first** (#554/#556, open) — to define "partitions" and their "entanglement entropy" at all.
-2. **The RT map must be constructed** (state → partition → area, with an argument that RT *holds* in the QBP substrate rather than being borrowed from AdS/CFT — #566 §5).
+**And edge 3 is not constructive** (confirmed: QBP has no RT map — only the #566 §5 statement that one is *needed*; the substrate work #554/#556 is the cohesive/type-theory layer, not an RT map). Worse than missing — it is **circular** (the infinite regress the adversary names):
+- edge 3 needs the **substrate geometry** to evaluate "area",
+- but the substrate geometry is **deformed by the potential** (the VEV) whose coefficients edge 3 is supposed to **determine.**
 
-Until both exist, **N_constraint cannot be counted, the closure fixed-point cannot be written, and sign(N_constraint − N_free) cannot be evaluated.** The bootstrap *cannot be posed.*
+So edge 3 must know its own output to produce its input. Plus the prerequisite that the substrate (#554/#556) be concrete before "partition" / "entropy" even mean anything. **N_constraint cannot be counted, its rank cannot be assessed, the closure fixed-point cannot be written, sign(N_constraint − N_free) cannot be evaluated.** The bootstrap *cannot be posed* — and the obstruction is self-referential, not merely a missing part.
 
 ## 5. The deeper structural point (why edge 3 is unavoidable, not a dodge)
 
 The loop is three **kinematic** maps (algebra structure → geometry → entanglement → algebra). The **values** live in the **dynamical** sector (the potential coefficients → VEV). A consistency condition on the kinematic loop reaches the dynamical coefficients **only if** the geometry depends on the VEV (so the dynamics feeds the loop). In QBP it does — the geometry transitions 𝕆→ℍ as crystallisation proceeds — **but that coupling routes entirely through edge 3** (the VEV changes the areas, which via RT change the substrate, which must host the algebra). So edge 3 is not one edge among three; it is **the only channel through which loop-closure can touch the values.** No edge 3 ⇒ the loop is value-blind. This is a structural result, not an excuse.
 
-## 6. Verdict — the machine is ~⅔ built; the generator question reduces to ONE construction
+## 6. Verdict — 0% built as a generator; the real result is the formal isolation of the boundary
 
-> **The loop-closure machine's counting framework is built and N_free ≈ 2 is in hand. The entire "generator vs organization" question now reduces to a single, precisely-isolated construction: a constructive holographic (RT) edge — entropy(partition) = area — in a concretized QBP substrate.** With it, N_constraint is countable (plausibly ≫ N_free → over-determined → predict-or-falsify). Without it, the bootstrap cannot be posed, so it cannot over-determine the values, and **"organization, not generator" stands** — *but the open question is now one well-defined object, not a vague program.*
+The "~⅔ built" framing is **retracted** (adversary, correctly): *a generator that cannot generate is 0% built.* Edge 3 is not a missing wheel — it **is the entire dynamical computation**, and it is both non-constructive and self-referentially circular (§4). So:
 
-The dependency chain to finish the machine: **concrete substrate (#554/#556) → RT map (edge 3) → count N_constraint → sign(N_c − N_f).** This is the honest state: option 1's last path is not closed, but it is reduced to building the holographic edge — and that edge was independently flagged (#566 §5) as the triangle's make-or-break.
+> **The loop-closure machine is 0% built as a generator, and the obstruction is structural, not logistical.** The honest, genuine result of this build is **the formal isolation of the boundary between QBP's kinematic successes and its dynamical void**: the ℍ→𝕆 algebra rigidly fixes the *menu* of states (representations, symmetries — the kinematics that *do* gate-pass, #571/#548) but has **no intrinsic scale to assign weights** (masses, couplings — the values). The loop is value-blind except through edge 3, and edge 3 is a ghost (non-constructive + circular). **"Organization, not generator" therefore stands indefinitely** — not "until one construction is finished," but until the self-referential dynamical-closure problem is solved, which this build shows is the *whole* difficulty, cleanly localized.
+
+What was actually achieved: the dynamical void is no longer vague — it is **proven to be the entirety of the gap** (the kinematics work; the dynamics is the ghost), and the obstruction is **named precisely** (a non-constructive, circular RT edge). That is a real theoretical result — the perimeter of the problem, mapped — but it is **not** a partially-built generator.
 
 ## 7. Provenance
-Option 1, the loop-closure "generator" long shot (#566/#570), 2026-06-18. The DOF framework, the N_free≈2 count, and the structural result that edge 3 is the sole value-channel are this build's results; the holographic edge's non-existence is confirmed against QBP's current substrate work. `loop_closure_dof.py`. Recorded by @qbp-oppenheimer; adversarially tested before adoption (see PR thread).
+Option 1, the loop-closure "generator" long shot (#566/#570), 2026-06-18. First draft (DOF framework, N_free≈2, "⅔ built, reduces to one construction") was **adversarially hardened** (Gemini Furey/Feynman, APPROVE-WITH-CONCERN): N_free is a massive undercount (substrate configurational DOF), "N_constraint ≫ N_free" is hand-waving (rank, not count — likely degenerate), edge 3 is **circular** (needs the geometry it determines), and "⅔ built" is spin ("0% built as a generator"). The surviving, genuine result is the structural one the adversary confirmed: **edge 3 is the sole value-channel, the loop is otherwise value-blind**, so this build **formally isolates the boundary between QBP's kinematic successes and its dynamical void** — organization-not-generator stands indefinitely. `loop_closure_dof.py`. Recorded by @qbp-oppenheimer.

--- a/analysis/566-loop-closure-machine/loop_closure_dof.py
+++ b/analysis/566-loop-closure-machine/loop_closure_dof.py
@@ -1,0 +1,51 @@
+"""
+Loop-closure DOF framework (#566). Minimal truncation: ℍ→𝕆.
+Enumerate N_free (sealed parameter space) and the SOURCE of N_constraint per edge.
+The point is the BOOKKEEPING + isolating the gate, not a final count (edge 3 is non-constructive).
+"""
+
+print("=== Sealed parameter space (ℍ→𝕆 truncation) ===")
+print("  octonion product : FIXED (Cayley-Dickson) -> 0 free")
+print(
+    "  metric/norm form : FIXED (Euclidean, #474 D10) -> 0 free (overall scale = units)"
+)
+print("  potential V(y)=a|y|^2 + b Re<Xy,yX> + c(|y|^2)^2, background |X|")
+raw = ["a", "b", "c", "|X|"]
+print(f"  raw potential coeffs: {raw}  (4)")
+print("  remove overall scale (units) -> dimensionless dynamical content:")
+print("    ~ {m^2/scale (m^2=a-b|X|^2),  quartic depth}  => N_free ≈ 2")
+Nfree = 2
+print(f"\nN_free ≈ {Nfree} (dimensionless dynamical)")
+
+print("\n=== N_constraint sources per edge ===")
+print(
+    "  edge1 Substrate->Foundation (hosting): constrains the SUBSTRATE, not V's coeffs -> 0 on N_free"
+)
+print(
+    "  edge2 Foundation->Physics (rigid metric): geometry fixed -> 0 free, but no constraint on V either"
+)
+print(
+    "  edge3 Physics->Substrate (RT: entropy(partition)=area): the ONLY source of constraints on the"
+)
+print(
+    "        dynamics -- and ONLY because V's VEV deforms the geometry/areas as 𝕆->ℍ proceeds."
+)
+print(
+    "        At a finite truncation #partitions is finite but >2 -> plausibly N_constraint >> N_free."
+)
+print("\n=== GATE ===")
+print(
+    "  edge3 is NON-CONSTRUCTIVE (no RT map in QBP; substrate #554/#556 not yet concrete)."
+)
+print(
+    "  => N_constraint UNCOUNTABLE => sign(N_constraint - N_free) UNEVALUABLE => bootstrap UNPOSABLE."
+)
+print(
+    "  Structural: edge3 is the SOLE channel by which loop-closure touches the values"
+)
+print(
+    "  (the loop is otherwise kinematic/value-blind). So the generator question reduces to"
+)
+print(
+    "  constructing edge3 (RT in a concrete substrate). Until then: organization, not generator."
+)

--- a/analysis/566-loop-closure-machine/loop_closure_dof_output.txt
+++ b/analysis/566-loop-closure-machine/loop_closure_dof_output.txt
@@ -1,0 +1,23 @@
+=== Sealed parameter space (ℍ→𝕆 truncation) ===
+  octonion product : FIXED (Cayley-Dickson) -> 0 free
+  metric/norm form : FIXED (Euclidean, #474 D10) -> 0 free (overall scale = units)
+  potential V(y)=a|y|^2 + b Re<Xy,yX> + c(|y|^2)^2, background |X|
+  raw potential coeffs: ['a', 'b', 'c', '|X|']  (4)
+  remove overall scale (units) -> dimensionless dynamical content:
+    ~ {m^2/scale (m^2=a-b|X|^2),  quartic depth}  => N_free ≈ 2
+
+N_free ≈ 2 (dimensionless dynamical)
+
+=== N_constraint sources per edge ===
+  edge1 Substrate->Foundation (hosting): constrains the SUBSTRATE, not V's coeffs -> 0 on N_free
+  edge2 Foundation->Physics (rigid metric): geometry fixed -> 0 free, but no constraint on V either
+  edge3 Physics->Substrate (RT: entropy(partition)=area): the ONLY source of constraints on the
+        dynamics -- and ONLY because V's VEV deforms the geometry/areas as 𝕆->ℍ proceeds.
+        At a finite truncation #partitions is finite but >2 -> plausibly N_constraint >> N_free.
+
+=== GATE ===
+  edge3 is NON-CONSTRUCTIVE (no RT map in QBP; substrate #554/#556 not yet concrete).
+  => N_constraint UNCOUNTABLE => sign(N_constraint - N_free) UNEVALUABLE => bootstrap UNPOSABLE.
+  Structural: edge3 is the SOLE channel by which loop-closure touches the values
+  (the loop is otherwise kinematic/value-blind). So the generator question reduces to
+  constructing edge3 (RT in a concrete substrate). Until then: organization, not generator.

--- a/archive/cth-inventory/confluent-trust-inventory-v5_3.v0.3.json
+++ b/archive/cth-inventory/confluent-trust-inventory-v5_3.v0.3.json
@@ -4281,6 +4281,76 @@
       "prediction_chain": [],
       "last_tested_at": "2026-06-14T00:00:00Z",
       "notes": "Citation real; QBP-relevance is precedent only, not shared machinery. Not load-bearing."
+    },
+    {
+      "id": "DEFN-purely-algebraic-derivation-gate",
+      "name": "The #570 gate: every QBP prediction must derive its bridge quantities purely from the algebra",
+      "description": "Governing principle (issue #570). A QBP bridge quantity counts as a real prediction only if (g1) derived from the algebra not fitted/borrowed, (g2) orthogonal to the standard-physics parameter it would be confused with (mass, spin, the SM constants), (g3) yields a dimensionless number/relation. Fitted, borrowed, or embedding-tautological quantities are degenerate-by-construction and are NOT predictions.",
+      "tier": 1,
+      "provenance": "T",
+      "provenance_kind": "theory",
+      "status": "coherent",
+      "measured_source": "QBP internal result 2026-06-17/18 (#570-#573)",
+      "prediction_chain": [],
+      "last_tested_at": "2026-06-18T00:00:00Z",
+      "notes": "The standing gate for all QBP prediction work. Adjudicated the APC line-181/193 inconsistency (#571)."
+    },
+    {
+      "id": "INSIGHT-footprint-cd-dimension-pyrrhic",
+      "name": "Footprint n = Cayley-Dickson dimension: first gate-passing quantity, but pyrrhic",
+      "description": "n = CD-dimension (ℝ1/ℂ2/ℍ4/𝕆8 = 2^k) is the unique gate-passing reading of the algebraic footprint (adversary-confirmed: real derivation, mass-orthogonal to mass MAGNITUDE; the 'n∝mass' and 'n=4+spin DOF' readings FAIL the gate). PYRRHIC: n=4 for all matter => ΔF∝(n_A−n_B)=0 for every matter-matter experiment (trapped-ion Test C predicted cleanly null); the only nonzero distinct prediction is cross-level atom-photon (n=4 vs 2) at relativistic γ. #571.",
+      "tier": 2,
+      "provenance": "T",
+      "provenance_kind": "theory",
+      "status": "coherent",
+      "measured_source": "QBP internal result 2026-06-17/18 (#570-#573)",
+      "prediction_chain": [],
+      "last_tested_at": "2026-06-18T00:00:00Z",
+      "notes": "First content-distinct gate-pass; coarse/pyrrhic. analysis/570-purely-algebraic-n/."
+    },
+    {
+      "id": "INSIGHT-constants-no-content-distinct",
+      "name": "On the SM constants, QBP derives nothing content-distinct from standard physics",
+      "description": "Applying the #570 gate to QBP's existing constant work (f0/spectral-action, Koide): the 'relations' it gets (sin²θ_W=3/8, multiplicity ratios) are STANDARD GROUP-THEORY tautologies of the embedding (any SU(5)-flavoured model gives them, not QBP-novel); the one QBP-specific relation δ₁=δ₃ FAILS the gate on look-elsewhere (best of 12 models, 9%); and NO continuous value (α, masses, m_H) derives — all value-attempts import a fitted/measured magnitude. #572.",
+      "tier": 2,
+      "provenance": "T",
+      "provenance_kind": "theory",
+      "status": "coherent",
+      "measured_source": "QBP internal result 2026-06-17/18 (#570-#573)",
+      "prediction_chain": [],
+      "last_tested_at": "2026-06-18T00:00:00Z",
+      "notes": "Proven invariants C=12, the 42 are real math but predict no physical constant. analysis/570-constants-target/."
+    },
+    {
+      "id": "INSIGHT-loop-closure-structural-obstruction",
+      "name": "The triangle loop-closure 'generator' machine is 0% built; the obstruction is structural",
+      "description": "The only path from organization to generator (deriving constant VALUES) is triangle loop-closure over-determining the free data. Built the DOF framework (minimal ℍ→𝕆 truncation); result: edge 3 (Physics→Substrate, RT entropy=area) is the SOLE channel by which closure can touch the values (the loop is otherwise kinematic/value-blind), and edge 3 is NON-CONSTRUCTIVE and CIRCULAR (it needs the substrate geometry that the potential it should determine deforms). N_constraint uncountable (and likely rank-degenerate); the bootstrap cannot be posed. 0% built as a generator. #573.",
+      "tier": 2,
+      "provenance": "T",
+      "provenance_kind": "theory",
+      "status": "coherent",
+      "measured_source": "QBP internal result 2026-06-17/18 (#570-#573)",
+      "prediction_chain": [],
+      "last_tested_at": "2026-06-18T00:00:00Z",
+      "notes": "Formally isolates the boundary between QBP's kinematic successes and its dynamical void. analysis/566-loop-closure-machine/."
+    },
+    {
+      "id": "QBP-POS-organization-not-generator",
+      "name": "QBP is a verified division-algebra ORGANIZATION of SM kinematics, not (yet) a GENERATOR of new physics",
+      "description": "Consolidated verdict of the #570→#573 investigation (option 1, purely-algebraic derivations, exhausted). QBP's kinematic core is real and Lean-verified (CD tower #474, G₂ gauge result #548, the 42, sin²θ_W=3/8) — a rigorous organization of SM group-theoretic structure. But with the current algebra it derives NO content-distinct physical prediction: no constant value, no novel relation beyond standard group theory, only the pyrrhic footprint. The generator path is structurally obstructed (loop-closure edge 3 non-constructive+circular). The kinematic/dynamic boundary is formally isolated; the algebra fixes the menu of states but has no intrinsic scale for the weights.",
+      "tier": 1,
+      "provenance": "T",
+      "provenance_kind": "theory",
+      "status": "coherent",
+      "measured_source": "QBP internal result 2026-06-17/18 (#570-#573)",
+      "prediction_chain": [
+        "DEFN-purely-algebraic-derivation-gate",
+        "INSIGHT-footprint-cd-dimension-pyrrhic",
+        "INSIGHT-constants-no-content-distinct",
+        "INSIGHT-loop-closure-structural-obstruction"
+      ],
+      "last_tested_at": "2026-06-18T00:00:00Z",
+      "notes": "The honest endpoint. Path to 'generator' requires solving the self-referential dynamical-closure problem (a concrete substrate + constructive RT edge)."
     }
   ],
   "inputs": [
@@ -4786,8 +4856,13 @@
       "version": "5.5.0",
       "date": "2026-06-14T00:00:00Z",
       "note": "qbp-oppenheimer: +14 anchors from the 2026-06-13/14 crystallisation work — #559 generator→DOF map (verified 7=(3,1)⊕(2,2); SSB ingredients; Higgs-interp killed), #539 direct-Γ observable (fixed-ratio deflated to generic; Th-229 instrument refs), the v→constants convergence keystone, QBP emergent-time position, and the three adversarially-killed-as-direct-map citations (Borsten SYM, causal sets, superpoint). AC5 of #559."
+    },
+    {
+      "version": "5.6.0",
+      "date": "2026-06-18T00:00:00Z",
+      "note": "qbp-oppenheimer: +5 anchors from the #570-#573 purely-algebraic-derivation investigation — the #570 gate (DEFN), footprint=CD-dimension (pyrrhic pass), constants (nothing content-distinct), loop-closure (0% built / structural obstruction), and the consolidated 'organization not generator' verdict. Brings CTH current with the option-1 result (V&V remediation: 'update CTH as we go')."
     }
   ],
-  "last_updated": "2026-06-14T00:00:00Z",
-  "update_provenance": "qbp-oppenheimer 2026-06-14: #559/#539/#560 findings + citation anchors (AC5)"
+  "last_updated": "2026-06-18T00:00:00Z",
+  "update_provenance": "qbp-oppenheimer 2026-06-18: #570-#573 option-1 findings (CTH-currency remediation)"
 }


### PR DESCRIPTION
## Summary
**V&V remediation (1 of 2):** brings the canonical CTH ledger **current** with the #570–#573 investigation. I had written "anchors in the next batch" in every PR's not-conflict box and never done the batch — a real lapse on the "update CTH as we go" discipline, which the beekeeper flagged. Fixed here.

## Anchors added (5) — 221 → 226
- `DEFN-purely-algebraic-derivation-gate` — the #570 governing gate (g1/g2/g3)
- `INSIGHT-footprint-cd-dimension-pyrrhic` — #571: n=CD-dimension, first gate-pass, pyrrhic
- `INSIGHT-constants-no-content-distinct` — #572: tautologies + look-elsewhere + no value
- `INSIGHT-loop-closure-structural-obstruction` — #573: 0% built, edge-3 non-constructive+circular
- `QBP-POS-organization-not-generator` — the consolidated verdict

These record findings already adversarially reviewed and merged (#571/#572/#573), so the review here is a **fidelity check** (do the anchors match the merged conclusions, status-correct, no overclaim).

## CTH anchor impact
- [x] theory-axis — 5 anchors into the QBP theory-state ledger; no schema change. Pure intake of merged findings.
- [ ] schema-axis · [ ] two-axis · [ ] not-conflict · [ ] N/A

## Test plan
- [x] JSON parses (226 anchors); `check_cth_invariants.py` passes; vendored v0.3 schema passes; changelog 5.6.0
- [x] statuses match the merged verdicts (the constants/loop-closure anchors record the *hardened* conclusions, not the first-draft overclaims)

Refs #570, #571, #572, #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)
